### PR TITLE
增加美国加州历史数据的抓取

### DIFF
--- a/crawler/us/ca/history/us_ca-daily-3.json
+++ b/crawler/us/ca/history/us_ca-daily-3.json
@@ -1,0 +1,14120 @@
+[
+    {
+        "drawTime": "20200806130000",
+        "jackpot": [
+            "$379"
+        ],
+        "numbers": "5|0|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 104,
+                        "prize": "$379"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 101,
+                        "prize": "$60"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 244,
+                        "prize": "$220"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 919,
+                        "prize": "$30"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16828",
+        "winnerCount": 1368
+    },
+    {
+        "drawTime": "20200805183000",
+        "jackpot": [
+            "$457"
+        ],
+        "numbers": "3|2|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 78,
+                        "prize": "$457"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 101,
+                        "prize": "$72"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 195,
+                        "prize": "$265"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1006,
+                        "prize": "$36"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16827",
+        "winnerCount": 1380
+    },
+    {
+        "drawTime": "20200805130000",
+        "jackpot": [
+            "$463"
+        ],
+        "numbers": "5|5|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 53,
+                        "prize": "$463"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 64,
+                        "prize": "$148"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 188,
+                        "prize": "$305"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 475,
+                        "prize": "$74"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16826",
+        "winnerCount": 780
+    },
+    {
+        "drawTime": "20200804183000",
+        "jackpot": [
+            "$347"
+        ],
+        "numbers": "2|3|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 70,
+                        "prize": "$347"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 263,
+                        "prize": "$54"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 221,
+                        "prize": "$201"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1739,
+                        "prize": "$27"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16825",
+        "winnerCount": 2293
+    },
+    {
+        "drawTime": "20200804130000",
+        "jackpot": [
+            "$546"
+        ],
+        "numbers": "5|5|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 23,
+                        "prize": "$546"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 62,
+                        "prize": "$174"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 194,
+                        "prize": "$360"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 391,
+                        "prize": "$87"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16824",
+        "winnerCount": 670
+    },
+    {
+        "drawTime": "20200803183000",
+        "jackpot": [
+            "$601"
+        ],
+        "numbers": "8|4|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 40,
+                        "prize": "$601"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 58,
+                        "prize": "$192"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 166,
+                        "prize": "$397"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 319,
+                        "prize": "$96"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16823",
+        "winnerCount": 583
+    },
+    {
+        "drawTime": "20200803130000",
+        "jackpot": [
+            "$709"
+        ],
+        "numbers": "9|6|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 22,
+                        "prize": "$709"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 70,
+                        "prize": "$112"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 148,
+                        "prize": "$411"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 752,
+                        "prize": "$56"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16822",
+        "winnerCount": 992
+    },
+    {
+        "drawTime": "20200802183000",
+        "jackpot": [
+            "$616"
+        ],
+        "numbers": "5|0|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 28,
+                        "prize": "$616"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 97,
+                        "prize": "$98"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 171,
+                        "prize": "$357"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 748,
+                        "prize": "$49"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16821",
+        "winnerCount": 1044
+    },
+    {
+        "drawTime": "20200802130000",
+        "jackpot": [
+            "$631"
+        ],
+        "numbers": "4|5|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 43,
+                        "prize": "$631"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 108,
+                        "prize": "$100"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 133,
+                        "prize": "$366"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 812,
+                        "prize": "$50"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16820",
+        "winnerCount": 1096
+    },
+    {
+        "drawTime": "20200801183000",
+        "jackpot": [
+            "$676"
+        ],
+        "numbers": "7|8|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 22,
+                        "prize": "$676"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 58,
+                        "prize": "$216"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 159,
+                        "prize": "$446"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 342,
+                        "prize": "$108"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16819",
+        "winnerCount": 581
+    },
+    {
+        "drawTime": "20200801130000",
+        "jackpot": [
+            "$584"
+        ],
+        "numbers": "7|5|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 53,
+                        "prize": "$584"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 124,
+                        "prize": "$92"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 132,
+                        "prize": "$339"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1005,
+                        "prize": "$46"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16818",
+        "winnerCount": 1314
+    },
+    {
+        "drawTime": "20200731183000",
+        "jackpot": [
+            "$521"
+        ],
+        "numbers": "7|4|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 58,
+                        "prize": "$521"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 104,
+                        "prize": "$82"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 197,
+                        "prize": "$302"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 931,
+                        "prize": "$41"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16817",
+        "winnerCount": 1290
+    },
+    {
+        "drawTime": "20200731130000",
+        "jackpot": [
+            "$535"
+        ],
+        "numbers": "4|6|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 53,
+                        "prize": "$535"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 151,
+                        "prize": "$84"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 165,
+                        "prize": "$310"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 930,
+                        "prize": "$42"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16816",
+        "winnerCount": 1299
+    },
+    {
+        "drawTime": "20200730183000",
+        "jackpot": [
+            "$463"
+        ],
+        "numbers": "6|0|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 53,
+                        "prize": "$463"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 110,
+                        "prize": "$74"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 204,
+                        "prize": "$268"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1066,
+                        "prize": "$37"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16815",
+        "winnerCount": 1433
+    },
+    {
+        "drawTime": "20200730130000",
+        "jackpot": [
+            "$633"
+        ],
+        "numbers": "4|5|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 26,
+                        "prize": "$633"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 95,
+                        "prize": "$100"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 145,
+                        "prize": "$367"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 829,
+                        "prize": "$50"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16814",
+        "winnerCount": 1095
+    },
+    {
+        "drawTime": "20200729183000",
+        "jackpot": [
+            "$664"
+        ],
+        "numbers": "5|6|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 23,
+                        "prize": "$664"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 90,
+                        "prize": "$106"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 157,
+                        "prize": "$385"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 776,
+                        "prize": "$53"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16813",
+        "winnerCount": 1046
+    },
+    {
+        "drawTime": "20200729130000",
+        "jackpot": [
+            "$583"
+        ],
+        "numbers": "7|0|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 28,
+                        "prize": "$583"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 97,
+                        "prize": "$92"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 177,
+                        "prize": "$338"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 791,
+                        "prize": "$46"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16812",
+        "winnerCount": 1093
+    },
+    {
+        "drawTime": "20200728183000",
+        "jackpot": [
+            "$740"
+        ],
+        "numbers": "3|8|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 20,
+                        "prize": "$740"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 104,
+                        "prize": "$118"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 68,
+                        "prize": "$429"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1153,
+                        "prize": "$59"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16811",
+        "winnerCount": 1345
+    },
+    {
+        "drawTime": "20200728130000",
+        "jackpot": [
+            "$563"
+        ],
+        "numbers": "5|8|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 61,
+                        "prize": "$563"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 55,
+                        "prize": "$90"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 131,
+                        "prize": "$326"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 829,
+                        "prize": "$45"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16810",
+        "winnerCount": 1076
+    },
+    {
+        "drawTime": "20200727183000",
+        "jackpot": [
+            "$533"
+        ],
+        "numbers": "6|4|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 60,
+                        "prize": "$533"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 78,
+                        "prize": "$84"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 165,
+                        "prize": "$309"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 741,
+                        "prize": "$42"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16809",
+        "winnerCount": 1044
+    },
+    {
+        "drawTime": "20200727130000",
+        "jackpot": [
+            "$638"
+        ],
+        "numbers": "6|3|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 32,
+                        "prize": "$638"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 59,
+                        "prize": "$102"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 144,
+                        "prize": "$370"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 706,
+                        "prize": "$51"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16808",
+        "winnerCount": 941
+    },
+    {
+        "drawTime": "20200726183000",
+        "jackpot": [
+            "$380"
+        ],
+        "numbers": "8|1|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 74,
+                        "prize": "$380"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 126,
+                        "prize": "$60"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 238,
+                        "prize": "$220"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 994,
+                        "prize": "$30"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16807",
+        "winnerCount": 1432
+    },
+    {
+        "drawTime": "20200726130000",
+        "jackpot": [
+            "$425"
+        ],
+        "numbers": "4|6|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 66,
+                        "prize": "$425"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 117,
+                        "prize": "$68"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 208,
+                        "prize": "$246"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 979,
+                        "prize": "$34"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16806",
+        "winnerCount": 1370
+    },
+    {
+        "drawTime": "20200725183000",
+        "jackpot": [
+            "$692"
+        ],
+        "numbers": "2|5|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 20,
+                        "prize": "$692"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 132,
+                        "prize": "$110"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 122,
+                        "prize": "$401"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 952,
+                        "prize": "$55"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16805",
+        "winnerCount": 1226
+    },
+    {
+        "drawTime": "20200725130000",
+        "jackpot": [
+            "$282"
+        ],
+        "numbers": "8|1|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 103,
+                        "prize": "$282"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 85,
+                        "prize": "$90"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 389,
+                        "prize": "$186"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 401,
+                        "prize": "$45"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16804",
+        "winnerCount": 978
+    },
+    {
+        "drawTime": "20200724183000",
+        "jackpot": [
+            "$313"
+        ],
+        "numbers": "9|0|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 118,
+                        "prize": "$313"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 92,
+                        "prize": "$100"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 334,
+                        "prize": "$207"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 422,
+                        "prize": "$50"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16803",
+        "winnerCount": 966
+    },
+    {
+        "drawTime": "20200724130000",
+        "jackpot": [
+            "$560"
+        ],
+        "numbers": "4|8|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 47,
+                        "prize": "$560"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 121,
+                        "prize": "$88"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 143,
+                        "prize": "$325"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1028,
+                        "prize": "$44"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16802",
+        "winnerCount": 1339
+    },
+    {
+        "drawTime": "20200723183000",
+        "jackpot": [
+            "$518"
+        ],
+        "numbers": "8|5|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 23,
+                        "prize": "$518"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 75,
+                        "prize": "$166"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 221,
+                        "prize": "$342"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 368,
+                        "prize": "$83"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16801",
+        "winnerCount": 687
+    },
+    {
+        "drawTime": "20200723130000",
+        "jackpot": [
+            "$513"
+        ],
+        "numbers": "3|0|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 38,
+                        "prize": "$513"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 103,
+                        "prize": "$82"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 163,
+                        "prize": "$297"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1161,
+                        "prize": "$41"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16800",
+        "winnerCount": 1465
+    },
+    {
+        "drawTime": "20200722183000",
+        "jackpot": [
+            "$590"
+        ],
+        "numbers": "1|3|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 30,
+                        "prize": "$590"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 99,
+                        "prize": "$94"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 169,
+                        "prize": "$342"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 914,
+                        "prize": "$47"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16799",
+        "winnerCount": 1212
+    },
+    {
+        "drawTime": "20200722130000",
+        "jackpot": [
+            "$719"
+        ],
+        "numbers": "4|0|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 33,
+                        "prize": "$719"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 70,
+                        "prize": "$114"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 109,
+                        "prize": "$417"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 771,
+                        "prize": "$57"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16798",
+        "winnerCount": 983
+    },
+    {
+        "drawTime": "20200721183000",
+        "jackpot": [
+            "$445"
+        ],
+        "numbers": "9|3|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 29,
+                        "prize": "$445"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 90,
+                        "prize": "$142"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 220,
+                        "prize": "$294"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 484,
+                        "prize": "$71"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16797",
+        "winnerCount": 823
+    },
+    {
+        "drawTime": "20200721130000",
+        "jackpot": [
+            "$267"
+        ],
+        "numbers": "7|9|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 258,
+                        "prize": "$267"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 99,
+                        "prize": "$42"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 163,
+                        "prize": "$155"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1016,
+                        "prize": "$21"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16796",
+        "winnerCount": 1536
+    },
+    {
+        "drawTime": "20200720183000",
+        "jackpot": [
+            "$441"
+        ],
+        "numbers": "9|6|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 25,
+                        "prize": "$441"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 153,
+                        "prize": "$70"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 230,
+                        "prize": "$255"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1196,
+                        "prize": "$35"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16795",
+        "winnerCount": 1604
+    },
+    {
+        "drawTime": "20200720130000",
+        "jackpot": [
+            "$588"
+        ],
+        "numbers": "8|7|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 26,
+                        "prize": "$588"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 77,
+                        "prize": "$94"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 160,
+                        "prize": "$341"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 838,
+                        "prize": "$47"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16794",
+        "winnerCount": 1101
+    },
+    {
+        "drawTime": "20200719183000",
+        "jackpot": [
+            "$497"
+        ],
+        "numbers": "7|4|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 35,
+                        "prize": "$497"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 91,
+                        "prize": "$78"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 188,
+                        "prize": "$288"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 980,
+                        "prize": "$39"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16793",
+        "winnerCount": 1294
+    },
+    {
+        "drawTime": "20200719130000",
+        "jackpot": [
+            "$461"
+        ],
+        "numbers": "2|1|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 72,
+                        "prize": "$461"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 131,
+                        "prize": "$72"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 171,
+                        "prize": "$267"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 816,
+                        "prize": "$36"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16792",
+        "winnerCount": 1190
+    },
+    {
+        "drawTime": "20200718183000",
+        "jackpot": [
+            "$472"
+        ],
+        "numbers": "5|3|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 41,
+                        "prize": "$472"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 105,
+                        "prize": "$74"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 201,
+                        "prize": "$273"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1228,
+                        "prize": "$37"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16791",
+        "winnerCount": 1575
+    },
+    {
+        "drawTime": "20200718130000",
+        "jackpot": [
+            "$648"
+        ],
+        "numbers": "0|4|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 49,
+                        "prize": "$648"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 70,
+                        "prize": "$102"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 138,
+                        "prize": "$376"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 699,
+                        "prize": "$51"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16790",
+        "winnerCount": 956
+    },
+    {
+        "drawTime": "20200717183000",
+        "jackpot": [
+            "$534"
+        ],
+        "numbers": "8|8|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 48,
+                        "prize": "$534"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 65,
+                        "prize": "$170"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 190,
+                        "prize": "$352"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 345,
+                        "prize": "$85"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16789",
+        "winnerCount": 648
+    },
+    {
+        "drawTime": "20200717130000",
+        "jackpot": [
+            "$528"
+        ],
+        "numbers": "5|5|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 42,
+                        "prize": "$528"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 48,
+                        "prize": "$168"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 198,
+                        "prize": "$348"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 351,
+                        "prize": "$84"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16788",
+        "winnerCount": 639
+    },
+    {
+        "drawTime": "20200716183000",
+        "jackpot": [
+            "$600"
+        ],
+        "numbers": "3|9|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 43,
+                        "prize": "$600"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 71,
+                        "prize": "$192"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 141,
+                        "prize": "$396"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 360,
+                        "prize": "$96"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16787",
+        "winnerCount": 615
+    },
+    {
+        "drawTime": "20200716130000",
+        "jackpot": [
+            "$340"
+        ],
+        "numbers": "9|0|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 68,
+                        "prize": "$340"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 172,
+                        "prize": "$54"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 309,
+                        "prize": "$197"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1098,
+                        "prize": "$27"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16786",
+        "winnerCount": 1647
+    },
+    {
+        "drawTime": "20200715183000",
+        "jackpot": [
+            "$570"
+        ],
+        "numbers": "7|0|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 63,
+                        "prize": "$570"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 79,
+                        "prize": "$90"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 154,
+                        "prize": "$330"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 737,
+                        "prize": "$45"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16785",
+        "winnerCount": 1033
+    },
+    {
+        "drawTime": "20200715130000",
+        "jackpot": [
+            "$560"
+        ],
+        "numbers": "8|9|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 27,
+                        "prize": "$560"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 128,
+                        "prize": "$88"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 167,
+                        "prize": "$325"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 947,
+                        "prize": "$44"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16784",
+        "winnerCount": 1269
+    },
+    {
+        "drawTime": "20200714183000",
+        "jackpot": [
+            "$466"
+        ],
+        "numbers": "2|1|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 57,
+                        "prize": "$466"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 96,
+                        "prize": "$74"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 204,
+                        "prize": "$270"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1010,
+                        "prize": "$37"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16783",
+        "winnerCount": 1367
+    },
+    {
+        "drawTime": "20200714130000",
+        "jackpot": [
+            "$585"
+        ],
+        "numbers": "4|6|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 32,
+                        "prize": "$585"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 109,
+                        "prize": "$92"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 169,
+                        "prize": "$339"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 710,
+                        "prize": "$46"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16782",
+        "winnerCount": 1020
+    },
+    {
+        "drawTime": "20200713183000",
+        "jackpot": [
+            "$446"
+        ],
+        "numbers": "9|1|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 62,
+                        "prize": "$446"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 89,
+                        "prize": "$70"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 230,
+                        "prize": "$258"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 785,
+                        "prize": "$35"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16781",
+        "winnerCount": 1166
+    },
+    {
+        "drawTime": "20200713130000",
+        "jackpot": [
+            "$715"
+        ],
+        "numbers": "1|4|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 30,
+                        "prize": "$715"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 120,
+                        "prize": "$114"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 94,
+                        "prize": "$415"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 763,
+                        "prize": "$57"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16780",
+        "winnerCount": 1007
+    },
+    {
+        "drawTime": "20200712183000",
+        "jackpot": [
+            "$588"
+        ],
+        "numbers": "6|8|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 19,
+                        "prize": "$588"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 113,
+                        "prize": "$94"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 149,
+                        "prize": "$341"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1007,
+                        "prize": "$47"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16779",
+        "winnerCount": 1288
+    },
+    {
+        "drawTime": "20200712130000",
+        "jackpot": [
+            "$422"
+        ],
+        "numbers": "1|3|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 55,
+                        "prize": "$422"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 125,
+                        "prize": "$66"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 210,
+                        "prize": "$244"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1111,
+                        "prize": "$33"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16778",
+        "winnerCount": 1501
+    },
+    {
+        "drawTime": "20200711183000",
+        "jackpot": [
+            "$579"
+        ],
+        "numbers": "4|6|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 35,
+                        "prize": "$579"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 106,
+                        "prize": "$92"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 182,
+                        "prize": "$335"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 839,
+                        "prize": "$46"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16777",
+        "winnerCount": 1162
+    },
+    {
+        "drawTime": "20200711130000",
+        "jackpot": [
+            "$552"
+        ],
+        "numbers": "9|4|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 33,
+                        "prize": "$552"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 58,
+                        "prize": "$176"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 185,
+                        "prize": "$364"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 405,
+                        "prize": "$88"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16776",
+        "winnerCount": 681
+    },
+    {
+        "drawTime": "20200710183000",
+        "jackpot": [
+            "$406"
+        ],
+        "numbers": "3|3|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 68,
+                        "prize": "$406"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 74,
+                        "prize": "$130"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 240,
+                        "prize": "$268"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 506,
+                        "prize": "$65"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16775",
+        "winnerCount": 888
+    },
+    {
+        "drawTime": "20200710130000",
+        "jackpot": [
+            "$559"
+        ],
+        "numbers": "5|7|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 73,
+                        "prize": "$559"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 94,
+                        "prize": "$88"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 129,
+                        "prize": "$324"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 888,
+                        "prize": "$44"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16774",
+        "winnerCount": 1184
+    },
+    {
+        "drawTime": "20200709183000",
+        "jackpot": [
+            "$537"
+        ],
+        "numbers": "9|1|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 46,
+                        "prize": "$537"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 119,
+                        "prize": "$86"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 186,
+                        "prize": "$311"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 876,
+                        "prize": "$43"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16773",
+        "winnerCount": 1227
+    },
+    {
+        "drawTime": "20200709130000",
+        "jackpot": [
+            "$537"
+        ],
+        "numbers": "5|8|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 29,
+                        "prize": "$537"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 51,
+                        "prize": "$172"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 188,
+                        "prize": "$354"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 409,
+                        "prize": "$86"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16772",
+        "winnerCount": 677
+    },
+    {
+        "drawTime": "20200708183000",
+        "jackpot": [
+            "$638"
+        ],
+        "numbers": "9|9|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 14,
+                        "prize": "$638"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 36,
+                        "prize": "$204"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 196,
+                        "prize": "$421"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 305,
+                        "prize": "$102"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16771",
+        "winnerCount": 551
+    },
+    {
+        "drawTime": "20200708130000",
+        "jackpot": [
+            "$398"
+        ],
+        "numbers": "3|1|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 58,
+                        "prize": "$398"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 116,
+                        "prize": "$62"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 289,
+                        "prize": "$231"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 845,
+                        "prize": "$31"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16770",
+        "winnerCount": 1308
+    },
+    {
+        "drawTime": "20200707183000",
+        "jackpot": [
+            "$533"
+        ],
+        "numbers": "8|4|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 58,
+                        "prize": "$533"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 113,
+                        "prize": "$84"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 167,
+                        "prize": "$309"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 809,
+                        "prize": "$42"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16769",
+        "winnerCount": 1147
+    },
+    {
+        "drawTime": "20200707130000",
+        "jackpot": [
+            "$649"
+        ],
+        "numbers": "0|0|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 42,
+                        "prize": "$649"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 56,
+                        "prize": "$206"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 121,
+                        "prize": "$428"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 309,
+                        "prize": "$103"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16768",
+        "winnerCount": 528
+    },
+    {
+        "drawTime": "20200706183000",
+        "jackpot": [
+            "$556"
+        ],
+        "numbers": "5|8|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 39,
+                        "prize": "$556"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 107,
+                        "prize": "$88"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 184,
+                        "prize": "$322"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 761,
+                        "prize": "$44"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16767",
+        "winnerCount": 1091
+    },
+    {
+        "drawTime": "20200706130000",
+        "jackpot": [
+            "$429"
+        ],
+        "numbers": "2|4|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 78,
+                        "prize": "$429"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 117,
+                        "prize": "$68"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 167,
+                        "prize": "$249"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1079,
+                        "prize": "$34"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16766",
+        "winnerCount": 1441
+    },
+    {
+        "drawTime": "20200705183000",
+        "jackpot": [
+            "$335"
+        ],
+        "numbers": "1|0|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 87,
+                        "prize": "$335"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 145,
+                        "prize": "$52"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 296,
+                        "prize": "$194"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 907,
+                        "prize": "$26"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16765",
+        "winnerCount": 1435
+    },
+    {
+        "drawTime": "20200705130000",
+        "jackpot": [
+            "$708"
+        ],
+        "numbers": "9|9|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 19,
+                        "prize": "$708"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 36,
+                        "prize": "$226"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 138,
+                        "prize": "$467"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 298,
+                        "prize": "$113"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16764",
+        "winnerCount": 491
+    },
+    {
+        "drawTime": "20200704183000",
+        "jackpot": [
+            "$597"
+        ],
+        "numbers": "5|5|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 34,
+                        "prize": "$597"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 81,
+                        "prize": "$190"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 142,
+                        "prize": "$394"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 375,
+                        "prize": "$95"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16763",
+        "winnerCount": 632
+    },
+    {
+        "drawTime": "20200704130000",
+        "jackpot": [
+            "$402"
+        ],
+        "numbers": "6|2|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 82,
+                        "prize": "$402"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 116,
+                        "prize": "$64"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 285,
+                        "prize": "$233"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 858,
+                        "prize": "$32"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16762",
+        "winnerCount": 1341
+    },
+    {
+        "drawTime": "20200703183000",
+        "jackpot": [
+            "$740"
+        ],
+        "numbers": "1|3|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 28,
+                        "prize": "$740"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 106,
+                        "prize": "$118"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 137,
+                        "prize": "$429"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 790,
+                        "prize": "$59"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16761",
+        "winnerCount": 1061
+    },
+    {
+        "drawTime": "20200703130000",
+        "jackpot": [
+            "$523"
+        ],
+        "numbers": "1|9|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 34,
+                        "prize": "$523"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 62,
+                        "prize": "$166"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 212,
+                        "prize": "$345"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 422,
+                        "prize": "$83"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16760",
+        "winnerCount": 730
+    },
+    {
+        "drawTime": "20200702183000",
+        "jackpot": [
+            "$697"
+        ],
+        "numbers": "2|8|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 26,
+                        "prize": "$697"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 105,
+                        "prize": "$110"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 114,
+                        "prize": "$404"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1071,
+                        "prize": "$55"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16759",
+        "winnerCount": 1316
+    },
+    {
+        "drawTime": "20200702130000",
+        "jackpot": [
+            "$560"
+        ],
+        "numbers": "0|9|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 29,
+                        "prize": "$560"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 140,
+                        "prize": "$88"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 185,
+                        "prize": "$325"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 933,
+                        "prize": "$44"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16758",
+        "winnerCount": 1287
+    },
+    {
+        "drawTime": "20200701183000",
+        "jackpot": [
+            "$693"
+        ],
+        "numbers": "5|8|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 21,
+                        "prize": "$693"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 135,
+                        "prize": "$110"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 135,
+                        "prize": "$402"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 888,
+                        "prize": "$55"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16757",
+        "winnerCount": 1179
+    },
+    {
+        "drawTime": "20200701130000",
+        "jackpot": [
+            "$712"
+        ],
+        "numbers": "1|9|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 19,
+                        "prize": "$712"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 52,
+                        "prize": "$226"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 136,
+                        "prize": "$469"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 323,
+                        "prize": "$113"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16756",
+        "winnerCount": 530
+    },
+    {
+        "drawTime": "20200630183000",
+        "jackpot": [
+            "$607"
+        ],
+        "numbers": "4|7|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 41,
+                        "prize": "$607"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 88,
+                        "prize": "$96"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 151,
+                        "prize": "$352"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 847,
+                        "prize": "$48"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16755",
+        "winnerCount": 1127
+    },
+    {
+        "drawTime": "20200630130000",
+        "jackpot": [
+            "$575"
+        ],
+        "numbers": "0|5|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 32,
+                        "prize": "$575"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 55,
+                        "prize": "$184"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 151,
+                        "prize": "$379"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 389,
+                        "prize": "$92"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16754",
+        "winnerCount": 627
+    },
+    {
+        "drawTime": "20200629183000",
+        "jackpot": [
+            "$475"
+        ],
+        "numbers": "2|4|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 66,
+                        "prize": "$475"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 97,
+                        "prize": "$76"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 172,
+                        "prize": "$275"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 941,
+                        "prize": "$38"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16753",
+        "winnerCount": 1276
+    },
+    {
+        "drawTime": "20200629130000",
+        "jackpot": [
+            "$438"
+        ],
+        "numbers": "3|1|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 53,
+                        "prize": "$438"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 99,
+                        "prize": "$70"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 201,
+                        "prize": "$254"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 899,
+                        "prize": "$35"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16752",
+        "winnerCount": 1252
+    },
+    {
+        "drawTime": "20200628183000",
+        "jackpot": [
+            "$606"
+        ],
+        "numbers": "8|9|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 23,
+                        "prize": "$606"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 99,
+                        "prize": "$96"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 139,
+                        "prize": "$351"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 935,
+                        "prize": "$48"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16751",
+        "winnerCount": 1196
+    },
+    {
+        "drawTime": "20200628130000",
+        "jackpot": [
+            "$491"
+        ],
+        "numbers": "9|6|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 44,
+                        "prize": "$491"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 99,
+                        "prize": "$78"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 156,
+                        "prize": "$284"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1052,
+                        "prize": "$39"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16750",
+        "winnerCount": 1351
+    },
+    {
+        "drawTime": "20200627183000",
+        "jackpot": [
+            "$838"
+        ],
+        "numbers": "6|3|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 27,
+                        "prize": "$838"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 64,
+                        "prize": "$134"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 110,
+                        "prize": "$486"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 629,
+                        "prize": "$67"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16749",
+        "winnerCount": 830
+    },
+    {
+        "drawTime": "20200627130000",
+        "jackpot": [
+            "$454"
+        ],
+        "numbers": "7|1|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 74,
+                        "prize": "$454"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 92,
+                        "prize": "$72"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 209,
+                        "prize": "$263"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 790,
+                        "prize": "$36"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16748",
+        "winnerCount": 1165
+    },
+    {
+        "drawTime": "20200626183000",
+        "jackpot": [
+            "$490"
+        ],
+        "numbers": "1|5|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 74,
+                        "prize": "$490"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 103,
+                        "prize": "$78"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 189,
+                        "prize": "$284"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 815,
+                        "prize": "$39"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16747",
+        "winnerCount": 1181
+    },
+    {
+        "drawTime": "20200626130000",
+        "jackpot": [
+            "$426"
+        ],
+        "numbers": "1|1|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 57,
+                        "prize": "$426"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 60,
+                        "prize": "$136"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 232,
+                        "prize": "$281"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 371,
+                        "prize": "$68"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16746",
+        "winnerCount": 720
+    },
+    {
+        "drawTime": "20200625183000",
+        "jackpot": [
+            "$299"
+        ],
+        "numbers": "6|1|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 97,
+                        "prize": "$299"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 146,
+                        "prize": "$46"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 369,
+                        "prize": "$173"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1092,
+                        "prize": "$23"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16745",
+        "winnerCount": 1704
+    },
+    {
+        "drawTime": "20200625130000",
+        "jackpot": [
+            "$368"
+        ],
+        "numbers": "0|6|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 87,
+                        "prize": "$368"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 105,
+                        "prize": "$58"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 220,
+                        "prize": "$213"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1141,
+                        "prize": "$29"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16744",
+        "winnerCount": 1553
+    },
+    {
+        "drawTime": "20200624183000",
+        "jackpot": [
+            "$557"
+        ],
+        "numbers": "0|5|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 26,
+                        "prize": "$557"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 68,
+                        "prize": "$178"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 165,
+                        "prize": "$367"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 421,
+                        "prize": "$89"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16743",
+        "winnerCount": 680
+    },
+    {
+        "drawTime": "20200624130000",
+        "jackpot": [
+            "$362"
+        ],
+        "numbers": "5|1|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 94,
+                        "prize": "$362"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 128,
+                        "prize": "$58"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 246,
+                        "prize": "$210"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 939,
+                        "prize": "$29"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16742",
+        "winnerCount": 1407
+    },
+    {
+        "drawTime": "20200623183000",
+        "jackpot": [
+            "$558"
+        ],
+        "numbers": "2|8|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 40,
+                        "prize": "$558"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 97,
+                        "prize": "$88"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 162,
+                        "prize": "$324"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 929,
+                        "prize": "$44"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16741",
+        "winnerCount": 1228
+    },
+    {
+        "drawTime": "20200623130000",
+        "jackpot": [
+            "$463"
+        ],
+        "numbers": "5|1|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 67,
+                        "prize": "$463"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 92,
+                        "prize": "$74"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 208,
+                        "prize": "$268"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 635,
+                        "prize": "$37"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16740",
+        "winnerCount": 1002
+    },
+    {
+        "drawTime": "20200622183000",
+        "jackpot": [
+            "$438"
+        ],
+        "numbers": "4|3|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 65,
+                        "prize": "$438"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 128,
+                        "prize": "$70"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 181,
+                        "prize": "$254"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1066,
+                        "prize": "$35"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16739",
+        "winnerCount": 1440
+    },
+    {
+        "drawTime": "20200622130000",
+        "jackpot": [
+            "$434"
+        ],
+        "numbers": "5|7|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 68,
+                        "prize": "$434"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 92,
+                        "prize": "$68"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 177,
+                        "prize": "$251"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 970,
+                        "prize": "$34"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16738",
+        "winnerCount": 1307
+    },
+    {
+        "drawTime": "20200621183000",
+        "jackpot": [
+            "$439"
+        ],
+        "numbers": "4|9|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 53,
+                        "prize": "$439"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 120,
+                        "prize": "$70"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 196,
+                        "prize": "$255"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 927,
+                        "prize": "$35"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16737",
+        "winnerCount": 1296
+    },
+    {
+        "drawTime": "20200621130000",
+        "jackpot": [
+            "$576"
+        ],
+        "numbers": "2|9|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 47,
+                        "prize": "$576"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 113,
+                        "prize": "$92"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 146,
+                        "prize": "$334"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 685,
+                        "prize": "$46"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16736",
+        "winnerCount": 991
+    },
+    {
+        "drawTime": "20200620183000",
+        "jackpot": [
+            "$362"
+        ],
+        "numbers": "4|8|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 92,
+                        "prize": "$362"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 123,
+                        "prize": "$56"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 282,
+                        "prize": "$210"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 938,
+                        "prize": "$28"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16735",
+        "winnerCount": 1435
+    },
+    {
+        "drawTime": "20200620130000",
+        "jackpot": [
+            "$610"
+        ],
+        "numbers": "5|9|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 32,
+                        "prize": "$610"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 92,
+                        "prize": "$96"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 146,
+                        "prize": "$354"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 870,
+                        "prize": "$48"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16734",
+        "winnerCount": 1140
+    },
+    {
+        "drawTime": "20200619183000",
+        "jackpot": [
+            "$349"
+        ],
+        "numbers": "9|1|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 106,
+                        "prize": "$349"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 125,
+                        "prize": "$54"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 304,
+                        "prize": "$202"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 881,
+                        "prize": "$27"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16733",
+        "winnerCount": 1416
+    },
+    {
+        "drawTime": "20200619130000",
+        "jackpot": [
+            "$461"
+        ],
+        "numbers": "9|3|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 57,
+                        "prize": "$461"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 108,
+                        "prize": "$72"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 203,
+                        "prize": "$267"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 941,
+                        "prize": "$36"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16732",
+        "winnerCount": 1309
+    },
+    {
+        "drawTime": "20200618183000",
+        "jackpot": [
+            "$625"
+        ],
+        "numbers": "6|6|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 23,
+                        "prize": "$625"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 52,
+                        "prize": "$200"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 142,
+                        "prize": "$413"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 414,
+                        "prize": "$100"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16731",
+        "winnerCount": 631
+    },
+    {
+        "drawTime": "20200618130000",
+        "jackpot": [
+            "$538"
+        ],
+        "numbers": "6|0|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 58,
+                        "prize": "$538"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 77,
+                        "prize": "$86"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 155,
+                        "prize": "$312"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 775,
+                        "prize": "$43"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16730",
+        "winnerCount": 1065
+    },
+    {
+        "drawTime": "20200617183000",
+        "jackpot": [
+            "$440"
+        ],
+        "numbers": "9|6|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 37,
+                        "prize": "$440"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 153,
+                        "prize": "$70"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 227,
+                        "prize": "$255"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1158,
+                        "prize": "$35"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16729",
+        "winnerCount": 1575
+    },
+    {
+        "drawTime": "20200617130000",
+        "jackpot": [
+            "$588"
+        ],
+        "numbers": "4|9|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 28,
+                        "prize": "$588"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 40,
+                        "prize": "$188"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 161,
+                        "prize": "$388"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 357,
+                        "prize": "$94"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16728",
+        "winnerCount": 586
+    },
+    {
+        "drawTime": "20200616183000",
+        "jackpot": [
+            "$670"
+        ],
+        "numbers": "3|8|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 28,
+                        "prize": "$670"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 68,
+                        "prize": "$106"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 151,
+                        "prize": "$389"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 740,
+                        "prize": "$53"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16727",
+        "winnerCount": 987
+    },
+    {
+        "drawTime": "20200616130000",
+        "jackpot": [
+            "$497"
+        ],
+        "numbers": "7|4|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 33,
+                        "prize": "$497"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 53,
+                        "prize": "$158"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 183,
+                        "prize": "$328"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 409,
+                        "prize": "$79"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16726",
+        "winnerCount": 678
+    },
+    {
+        "drawTime": "20200615183000",
+        "jackpot": [
+            "$600"
+        ],
+        "numbers": "8|2|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 40,
+                        "prize": "$600"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 104,
+                        "prize": "$96"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 156,
+                        "prize": "$348"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 705,
+                        "prize": "$48"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16725",
+        "winnerCount": 1005
+    },
+    {
+        "drawTime": "20200615130000",
+        "jackpot": [
+            "$689"
+        ],
+        "numbers": "7|3|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 23,
+                        "prize": "$689"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 87,
+                        "prize": "$110"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 122,
+                        "prize": "$400"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 763,
+                        "prize": "$55"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16724",
+        "winnerCount": 995
+    },
+    {
+        "drawTime": "20200614183000",
+        "jackpot": [
+            "$399"
+        ],
+        "numbers": "7|4|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 58,
+                        "prize": "$399"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 135,
+                        "prize": "$62"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 213,
+                        "prize": "$231"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1148,
+                        "prize": "$31"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16723",
+        "winnerCount": 1554
+    },
+    {
+        "drawTime": "20200614130000",
+        "jackpot": [
+            "$409"
+        ],
+        "numbers": "6|1|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 54,
+                        "prize": "$409"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 131,
+                        "prize": "$64"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 256,
+                        "prize": "$237"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 809,
+                        "prize": "$32"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16722",
+        "winnerCount": 1250
+    },
+    {
+        "drawTime": "20200613183000",
+        "jackpot": [
+            "$592"
+        ],
+        "numbers": "7|4|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 43,
+                        "prize": "$592"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 105,
+                        "prize": "$94"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 155,
+                        "prize": "$343"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 843,
+                        "prize": "$47"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16721",
+        "winnerCount": 1146
+    },
+    {
+        "drawTime": "20200613130000",
+        "jackpot": [
+            "$543"
+        ],
+        "numbers": "5|0|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 55,
+                        "prize": "$543"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 93,
+                        "prize": "$86"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 149,
+                        "prize": "$315"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 896,
+                        "prize": "$43"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16720",
+        "winnerCount": 1193
+    },
+    {
+        "drawTime": "20200612183000",
+        "jackpot": [
+            "$505"
+        ],
+        "numbers": "7|7|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 29,
+                        "prize": "$505"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 88,
+                        "prize": "$160"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 212,
+                        "prize": "$333"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 392,
+                        "prize": "$80"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16719",
+        "winnerCount": 721
+    },
+    {
+        "drawTime": "20200612130000",
+        "jackpot": [
+            "$818"
+        ],
+        "numbers": "3|7|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 7,
+                        "prize": "$818"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 119,
+                        "prize": "$130"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 108,
+                        "prize": "$474"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 795,
+                        "prize": "$65"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16718",
+        "winnerCount": 1029
+    },
+    {
+        "drawTime": "20200611183000",
+        "jackpot": [
+            "$428"
+        ],
+        "numbers": "4|2|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 64,
+                        "prize": "$428"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 59,
+                        "prize": "$136"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 247,
+                        "prize": "$282"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 258,
+                        "prize": "$68"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16717",
+        "winnerCount": 628
+    },
+    {
+        "drawTime": "20200611130000",
+        "jackpot": [
+            "$593"
+        ],
+        "numbers": "9|0|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 35,
+                        "prize": "$593"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 69,
+                        "prize": "$94"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 170,
+                        "prize": "$344"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 740,
+                        "prize": "$47"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16716",
+        "winnerCount": 1014
+    },
+    {
+        "drawTime": "20200610183000",
+        "jackpot": [
+            "$534"
+        ],
+        "numbers": "9|7|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 40,
+                        "prize": "$534"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 117,
+                        "prize": "$84"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 173,
+                        "prize": "$310"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 931,
+                        "prize": "$42"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16715",
+        "winnerCount": 1261
+    },
+    {
+        "drawTime": "20200610130000",
+        "jackpot": [
+            "$721"
+        ],
+        "numbers": "8|6|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 20,
+                        "prize": "$721"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 98,
+                        "prize": "$114"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 115,
+                        "prize": "$418"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 827,
+                        "prize": "$57"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16714",
+        "winnerCount": 1060
+    },
+    {
+        "drawTime": "20200609183000",
+        "jackpot": [
+            "$697"
+        ],
+        "numbers": "3|4|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 32,
+                        "prize": "$697"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 75,
+                        "prize": "$110"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 130,
+                        "prize": "$404"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 762,
+                        "prize": "$55"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16713",
+        "winnerCount": 999
+    },
+    {
+        "drawTime": "20200609130000",
+        "jackpot": [
+            "$422"
+        ],
+        "numbers": "6|1|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 63,
+                        "prize": "$422"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 107,
+                        "prize": "$66"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 249,
+                        "prize": "$245"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 719,
+                        "prize": "$33"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16712",
+        "winnerCount": 1138
+    },
+    {
+        "drawTime": "20200608183000",
+        "jackpot": [
+            "$407"
+        ],
+        "numbers": "3|5|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 68,
+                        "prize": "$407"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 92,
+                        "prize": "$64"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 242,
+                        "prize": "$236"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1014,
+                        "prize": "$32"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16711",
+        "winnerCount": 1416
+    },
+    {
+        "drawTime": "20200608130000",
+        "jackpot": [
+            "$446"
+        ],
+        "numbers": "0|2|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 48,
+                        "prize": "$446"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 98,
+                        "prize": "$70"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 197,
+                        "prize": "$259"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1044,
+                        "prize": "$35"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16710",
+        "winnerCount": 1387
+    },
+    {
+        "drawTime": "20200607183000",
+        "jackpot": [
+            "$592"
+        ],
+        "numbers": "8|8|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 39,
+                        "prize": "$592"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 41,
+                        "prize": "$188"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 165,
+                        "prize": "$391"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 258,
+                        "prize": "$94"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16709",
+        "winnerCount": 503
+    },
+    {
+        "drawTime": "20200607130000",
+        "jackpot": [
+            "$509"
+        ],
+        "numbers": "9|2|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 39,
+                        "prize": "$509"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 104,
+                        "prize": "$80"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 187,
+                        "prize": "$295"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 908,
+                        "prize": "$40"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16708",
+        "winnerCount": 1238
+    },
+    {
+        "drawTime": "20200606183000",
+        "jackpot": [
+            "$854"
+        ],
+        "numbers": "5|9|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 30,
+                        "prize": "$854"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 74,
+                        "prize": "$136"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 95,
+                        "prize": "$495"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 706,
+                        "prize": "$68"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16707",
+        "winnerCount": 905
+    },
+    {
+        "drawTime": "20200606130000",
+        "jackpot": [
+            "$416"
+        ],
+        "numbers": "1|2|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 94,
+                        "prize": "$416"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 93,
+                        "prize": "$66"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 235,
+                        "prize": "$241"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 778,
+                        "prize": "$33"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16706",
+        "winnerCount": 1200
+    },
+    {
+        "drawTime": "20200605183000",
+        "jackpot": [
+            "$459"
+        ],
+        "numbers": "7|1|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 66,
+                        "prize": "$459"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 136,
+                        "prize": "$72"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 239,
+                        "prize": "$266"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 849,
+                        "prize": "$36"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16705",
+        "winnerCount": 1290
+    },
+    {
+        "drawTime": "20200605130000",
+        "jackpot": [
+            "$591"
+        ],
+        "numbers": "2|8|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 27,
+                        "prize": "$591"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 95,
+                        "prize": "$94"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 160,
+                        "prize": "$343"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 970,
+                        "prize": "$47"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16704",
+        "winnerCount": 1252
+    },
+    {
+        "drawTime": "20200604183000",
+        "jackpot": [
+            "$596"
+        ],
+        "numbers": "5|8|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 15,
+                        "prize": "$596"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 96,
+                        "prize": "$94"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 203,
+                        "prize": "$346"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 850,
+                        "prize": "$47"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16703",
+        "winnerCount": 1164
+    },
+    {
+        "drawTime": "20200604130000",
+        "jackpot": [
+            "$778"
+        ],
+        "numbers": "7|9|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 20,
+                        "prize": "$778"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 73,
+                        "prize": "$124"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 123,
+                        "prize": "$451"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 702,
+                        "prize": "$62"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16702",
+        "winnerCount": 918
+    },
+    {
+        "drawTime": "20200603183000",
+        "jackpot": [
+            "$432"
+        ],
+        "numbers": "7|2|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 79,
+                        "prize": "$432"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 121,
+                        "prize": "$68"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 228,
+                        "prize": "$250"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 866,
+                        "prize": "$34"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16701",
+        "winnerCount": 1294
+    },
+    {
+        "drawTime": "20200603130000",
+        "jackpot": [
+            "$459"
+        ],
+        "numbers": "3|1|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 46,
+                        "prize": "$459"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 101,
+                        "prize": "$72"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 232,
+                        "prize": "$266"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 884,
+                        "prize": "$36"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16700",
+        "winnerCount": 1263
+    },
+    {
+        "drawTime": "20200602183000",
+        "jackpot": [
+            "$676"
+        ],
+        "numbers": "6|9|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 39,
+                        "prize": "$676"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 84,
+                        "prize": "$108"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 109,
+                        "prize": "$392"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 874,
+                        "prize": "$54"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16699",
+        "winnerCount": 1106
+    },
+    {
+        "drawTime": "20200602130000",
+        "jackpot": [
+            "$517"
+        ],
+        "numbers": "8|8|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 53,
+                        "prize": "$517"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 60,
+                        "prize": "$164"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 161,
+                        "prize": "$341"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 323,
+                        "prize": "$82"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16698",
+        "winnerCount": 597
+    },
+    {
+        "drawTime": "20200601183000",
+        "jackpot": [
+            "$526"
+        ],
+        "numbers": "2|9|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 47,
+                        "prize": "$526"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 117,
+                        "prize": "$84"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 159,
+                        "prize": "$305"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 858,
+                        "prize": "$42"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16697",
+        "winnerCount": 1181
+    },
+    {
+        "drawTime": "20200601130000",
+        "jackpot": [
+            "$489"
+        ],
+        "numbers": "1|1|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 32,
+                        "prize": "$489"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 83,
+                        "prize": "$156"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 206,
+                        "prize": "$323"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 304,
+                        "prize": "$78"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16696",
+        "winnerCount": 625
+    },
+    {
+        "drawTime": "20200531183000",
+        "jackpot": [
+            "$527"
+        ],
+        "numbers": "1|7|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 51,
+                        "prize": "$527"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 71,
+                        "prize": "$168"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 115,
+                        "prize": "$348"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 474,
+                        "prize": "$84"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16695",
+        "winnerCount": 711
+    },
+    {
+        "drawTime": "20200531130000",
+        "jackpot": [
+            "$469"
+        ],
+        "numbers": "4|2|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 71,
+                        "prize": "$469"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 97,
+                        "prize": "$74"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 190,
+                        "prize": "$272"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 733,
+                        "prize": "$37"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16694",
+        "winnerCount": 1091
+    },
+    {
+        "drawTime": "20200530183000",
+        "jackpot": [
+            "$560"
+        ],
+        "numbers": "0|1|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 52,
+                        "prize": "$560"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 82,
+                        "prize": "$88"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 164,
+                        "prize": "$325"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 921,
+                        "prize": "$44"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16693",
+        "winnerCount": 1219
+    },
+    {
+        "drawTime": "20200530130000",
+        "jackpot": [
+            "$491"
+        ],
+        "numbers": "0|3|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 38,
+                        "prize": "$491"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 129,
+                        "prize": "$78"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 171,
+                        "prize": "$284"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1265,
+                        "prize": "$39"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16692",
+        "winnerCount": 1603
+    },
+    {
+        "drawTime": "20200529183000",
+        "jackpot": [
+            "$545"
+        ],
+        "numbers": "0|1|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 46,
+                        "prize": "$545"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 96,
+                        "prize": "$86"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 172,
+                        "prize": "$316"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 993,
+                        "prize": "$43"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16691",
+        "winnerCount": 1307
+    },
+    {
+        "drawTime": "20200529130000",
+        "jackpot": [
+            "$593"
+        ],
+        "numbers": "4|8|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 34,
+                        "prize": "$593"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 137,
+                        "prize": "$94"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 122,
+                        "prize": "$344"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 976,
+                        "prize": "$47"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16690",
+        "winnerCount": 1269
+    },
+    {
+        "drawTime": "20200528183000",
+        "jackpot": [
+            "$488"
+        ],
+        "numbers": "7|2|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 46,
+                        "prize": "$488"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 110,
+                        "prize": "$78"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 211,
+                        "prize": "$283"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 813,
+                        "prize": "$39"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16689",
+        "winnerCount": 1180
+    },
+    {
+        "drawTime": "20200528130000",
+        "jackpot": [
+            "$540"
+        ],
+        "numbers": "6|3|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 42,
+                        "prize": "$540"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 115,
+                        "prize": "$86"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 164,
+                        "prize": "$313"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 803,
+                        "prize": "$43"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16688",
+        "winnerCount": 1124
+    },
+    {
+        "drawTime": "20200527183000",
+        "jackpot": [
+            "$713"
+        ],
+        "numbers": "1|8|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 28,
+                        "prize": "$713"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 107,
+                        "prize": "$114"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 100,
+                        "prize": "$413"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 822,
+                        "prize": "$57"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16687",
+        "winnerCount": 1057
+    },
+    {
+        "drawTime": "20200527130000",
+        "jackpot": [
+            "$575"
+        ],
+        "numbers": "9|9|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 25,
+                        "prize": "$575"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 37,
+                        "prize": "$184"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 177,
+                        "prize": "$380"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 299,
+                        "prize": "$92"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16686",
+        "winnerCount": 538
+    },
+    {
+        "drawTime": "20200526183000",
+        "jackpot": [
+            "$488"
+        ],
+        "numbers": "5|0|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 45,
+                        "prize": "$488"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 52,
+                        "prize": "$156"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 194,
+                        "prize": "$322"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 303,
+                        "prize": "$78"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16685",
+        "winnerCount": 594
+    },
+    {
+        "drawTime": "20200526130000",
+        "jackpot": [
+            "$418"
+        ],
+        "numbers": "8|2|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 62,
+                        "prize": "$418"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 134,
+                        "prize": "$66"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 192,
+                        "prize": "$242"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 857,
+                        "prize": "$33"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16684",
+        "winnerCount": 1245
+    },
+    {
+        "drawTime": "20200525183000",
+        "jackpot": [
+            "$626"
+        ],
+        "numbers": "3|7|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 34,
+                        "prize": "$626"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 98,
+                        "prize": "$100"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 133,
+                        "prize": "$363"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 627,
+                        "prize": "$50"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16683",
+        "winnerCount": 892
+    },
+    {
+        "drawTime": "20200525130000",
+        "jackpot": [
+            "$489"
+        ],
+        "numbers": "4|8|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 41,
+                        "prize": "$489"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 91,
+                        "prize": "$78"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 186,
+                        "prize": "$283"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 816,
+                        "prize": "$39"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16682",
+        "winnerCount": 1134
+    },
+    {
+        "drawTime": "20200524183000",
+        "jackpot": [
+            "$652"
+        ],
+        "numbers": "3|3|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 19,
+                        "prize": "$652"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 39,
+                        "prize": "$208"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 163,
+                        "prize": "$430"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 235,
+                        "prize": "$104"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16681",
+        "winnerCount": 456
+    },
+    {
+        "drawTime": "20200524130000",
+        "jackpot": [
+            "$504"
+        ],
+        "numbers": "4|5|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 36,
+                        "prize": "$504"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 125,
+                        "prize": "$80"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 159,
+                        "prize": "$292"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1004,
+                        "prize": "$40"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16680",
+        "winnerCount": 1324
+    },
+    {
+        "drawTime": "20200523183000",
+        "jackpot": [
+            "$488"
+        ],
+        "numbers": "1|5|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 44,
+                        "prize": "$488"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 123,
+                        "prize": "$78"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 152,
+                        "prize": "$283"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1228,
+                        "prize": "$39"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16679",
+        "winnerCount": 1547
+    },
+    {
+        "drawTime": "20200523130000",
+        "jackpot": [
+            "$272"
+        ],
+        "numbers": "8|8|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 447,
+                        "prize": "$272"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 0,
+                        "prize": "Free play"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 0,
+                        "prize": "Free play"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 0,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16678",
+        "winnerCount": 447
+    },
+    {
+        "drawTime": "20200522183000",
+        "jackpot": [
+            "$430"
+        ],
+        "numbers": "5|0|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 64,
+                        "prize": "$430"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 51,
+                        "prize": "$136"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 240,
+                        "prize": "$283"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 369,
+                        "prize": "$68"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16677",
+        "winnerCount": 724
+    },
+    {
+        "drawTime": "20200522130000",
+        "jackpot": [
+            "$399"
+        ],
+        "numbers": "4|1|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 73,
+                        "prize": "$399"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 77,
+                        "prize": "$126"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 229,
+                        "prize": "$263"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 341,
+                        "prize": "$63"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16676",
+        "winnerCount": 720
+    },
+    {
+        "drawTime": "20200521183000",
+        "jackpot": [
+            "$295"
+        ],
+        "numbers": "3|3|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 418,
+                        "prize": "$295"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 0,
+                        "prize": "Free play"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 0,
+                        "prize": "Free play"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 0,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16675",
+        "winnerCount": 418
+    },
+    {
+        "drawTime": "20200521130000",
+        "jackpot": [
+            "$671"
+        ],
+        "numbers": "6|8|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 26,
+                        "prize": "$671"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 93,
+                        "prize": "$106"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 126,
+                        "prize": "$389"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 828,
+                        "prize": "$53"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16674",
+        "winnerCount": 1073
+    },
+    {
+        "drawTime": "20200520183000",
+        "jackpot": [
+            "$415"
+        ],
+        "numbers": "7|1|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 73,
+                        "prize": "$415"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 138,
+                        "prize": "$66"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 221,
+                        "prize": "$240"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 995,
+                        "prize": "$33"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16673",
+        "winnerCount": 1427
+    },
+    {
+        "drawTime": "20200520130000",
+        "jackpot": [
+            "$442"
+        ],
+        "numbers": "8|5|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 47,
+                        "prize": "$442"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 128,
+                        "prize": "$70"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 194,
+                        "prize": "$256"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1087,
+                        "prize": "$35"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16672",
+        "winnerCount": 1456
+    },
+    {
+        "drawTime": "20200519183000",
+        "jackpot": [
+            "$691"
+        ],
+        "numbers": "0|0|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 34,
+                        "prize": "$691"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 40,
+                        "prize": "$220"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 124,
+                        "prize": "$456"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 320,
+                        "prize": "$110"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16671",
+        "winnerCount": 518
+    },
+    {
+        "drawTime": "20200519130000",
+        "jackpot": [
+            "$678"
+        ],
+        "numbers": "6|7|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 32,
+                        "prize": "$678"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 77,
+                        "prize": "$108"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 116,
+                        "prize": "$393"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 729,
+                        "prize": "$54"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16670",
+        "winnerCount": 954
+    },
+    {
+        "drawTime": "20200518183000",
+        "jackpot": [
+            "$635"
+        ],
+        "numbers": "4|0|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 30,
+                        "prize": "$635"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 107,
+                        "prize": "$100"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 146,
+                        "prize": "$368"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 687,
+                        "prize": "$50"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16669",
+        "winnerCount": 970
+    },
+    {
+        "drawTime": "20200518130000",
+        "jackpot": [
+            "$580"
+        ],
+        "numbers": "9|0|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 40,
+                        "prize": "$580"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 67,
+                        "prize": "$92"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 156,
+                        "prize": "$336"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 594,
+                        "prize": "$46"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16668",
+        "winnerCount": 857
+    },
+    {
+        "drawTime": "20200517183000",
+        "jackpot": [
+            "$537"
+        ],
+        "numbers": "7|2|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 50,
+                        "prize": "$537"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 102,
+                        "prize": "$86"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 151,
+                        "prize": "$311"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 738,
+                        "prize": "$43"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16667",
+        "winnerCount": 1041
+    },
+    {
+        "drawTime": "20200517130000",
+        "jackpot": [
+            "$834"
+        ],
+        "numbers": "1|9|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 20,
+                        "prize": "$834"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 41,
+                        "prize": "$132"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 90,
+                        "prize": "$483"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 735,
+                        "prize": "$66"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16666",
+        "winnerCount": 886
+    },
+    {
+        "drawTime": "20200516183000",
+        "jackpot": [
+            "$398"
+        ],
+        "numbers": "8|3|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 73,
+                        "prize": "$398"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 117,
+                        "prize": "$62"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 248,
+                        "prize": "$231"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 941,
+                        "prize": "$31"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16665",
+        "winnerCount": 1379
+    },
+    {
+        "drawTime": "20200516130000",
+        "jackpot": [
+            "$522"
+        ],
+        "numbers": "3|8|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 32,
+                        "prize": "$522"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 65,
+                        "prize": "$82"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 213,
+                        "prize": "$303"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 851,
+                        "prize": "$41"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16664",
+        "winnerCount": 1161
+    },
+    {
+        "drawTime": "20200515183000",
+        "jackpot": [
+            "$520"
+        ],
+        "numbers": "6|1|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 45,
+                        "prize": "$520"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 103,
+                        "prize": "$82"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 224,
+                        "prize": "$301"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 704,
+                        "prize": "$41"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16663",
+        "winnerCount": 1076
+    },
+    {
+        "drawTime": "20200515130000",
+        "jackpot": [
+            "$513"
+        ],
+        "numbers": "5|5|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 41,
+                        "prize": "$513"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 57,
+                        "prize": "$164"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 177,
+                        "prize": "$338"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 370,
+                        "prize": "$82"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16662",
+        "winnerCount": 645
+    },
+    {
+        "drawTime": "20200514183000",
+        "jackpot": [
+            "$476"
+        ],
+        "numbers": "2|2|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 63,
+                        "prize": "$476"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 46,
+                        "prize": "$152"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 204,
+                        "prize": "$314"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 280,
+                        "prize": "$76"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16661",
+        "winnerCount": 593
+    },
+    {
+        "drawTime": "20200514130000",
+        "jackpot": [
+            "$725"
+        ],
+        "numbers": "7|9|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 19,
+                        "prize": "$725"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 85,
+                        "prize": "$116"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 113,
+                        "prize": "$420"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 794,
+                        "prize": "$58"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16660",
+        "winnerCount": 1011
+    },
+    {
+        "drawTime": "20200513183000",
+        "jackpot": [
+            "$479"
+        ],
+        "numbers": "1|0|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 61,
+                        "prize": "$479"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 100,
+                        "prize": "$76"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 209,
+                        "prize": "$278"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 683,
+                        "prize": "$38"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16659",
+        "winnerCount": 1053
+    },
+    {
+        "drawTime": "20200513130000",
+        "jackpot": [
+            "$731"
+        ],
+        "numbers": "2|9|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 23,
+                        "prize": "$731"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 44,
+                        "prize": "$234"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 112,
+                        "prize": "$482"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 287,
+                        "prize": "$117"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16658",
+        "winnerCount": 466
+    },
+    {
+        "drawTime": "20200512183000",
+        "jackpot": [
+            "$548"
+        ],
+        "numbers": "5|4|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 30,
+                        "prize": "$548"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 84,
+                        "prize": "$86"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 184,
+                        "prize": "$317"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 837,
+                        "prize": "$43"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16657",
+        "winnerCount": 1135
+    },
+    {
+        "drawTime": "20200512130000",
+        "jackpot": [
+            "$720"
+        ],
+        "numbers": "7|8|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 25,
+                        "prize": "$720"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 83,
+                        "prize": "$114"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 104,
+                        "prize": "$418"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 682,
+                        "prize": "$57"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16656",
+        "winnerCount": 894
+    },
+    {
+        "drawTime": "20200511183000",
+        "jackpot": [
+            "$579"
+        ],
+        "numbers": "4|4|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 40,
+                        "prize": "$579"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 49,
+                        "prize": "$184"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 125,
+                        "prize": "$382"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 366,
+                        "prize": "$92"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16655",
+        "winnerCount": 580
+    },
+    {
+        "drawTime": "20200511130000",
+        "jackpot": [
+            "$419"
+        ],
+        "numbers": "5|1|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 60,
+                        "prize": "$419"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 87,
+                        "prize": "$66"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 227,
+                        "prize": "$243"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 610,
+                        "prize": "$33"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16654",
+        "winnerCount": 984
+    },
+    {
+        "drawTime": "20200510183000",
+        "jackpot": [
+            "$360"
+        ],
+        "numbers": "8|6|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 73,
+                        "prize": "$360"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 72,
+                        "prize": "$56"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 281,
+                        "prize": "$208"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 729,
+                        "prize": "$28"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16653",
+        "winnerCount": 1155
+    },
+    {
+        "drawTime": "20200510130000",
+        "jackpot": [
+            "$521"
+        ],
+        "numbers": "2|9|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 49,
+                        "prize": "$521"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 73,
+                        "prize": "$82"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 145,
+                        "prize": "$302"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 873,
+                        "prize": "$41"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16652",
+        "winnerCount": 1140
+    },
+    {
+        "drawTime": "20200509183000",
+        "jackpot": [
+            "$415"
+        ],
+        "numbers": "9|1|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 79,
+                        "prize": "$415"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 102,
+                        "prize": "$66"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 226,
+                        "prize": "$240"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 864,
+                        "prize": "$33"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16651",
+        "winnerCount": 1271
+    },
+    {
+        "drawTime": "20200509130000",
+        "jackpot": [
+            "$610"
+        ],
+        "numbers": "2|5|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 53,
+                        "prize": "$610"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 100,
+                        "prize": "$96"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 101,
+                        "prize": "$353"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 824,
+                        "prize": "$48"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16650",
+        "winnerCount": 1078
+    },
+    {
+        "drawTime": "20200508183000",
+        "jackpot": [
+            "$469"
+        ],
+        "numbers": "5|8|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 41,
+                        "prize": "$469"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 113,
+                        "prize": "$74"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 224,
+                        "prize": "$272"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 951,
+                        "prize": "$37"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16649",
+        "winnerCount": 1329
+    },
+    {
+        "drawTime": "20200508130000",
+        "jackpot": [
+            "$555"
+        ],
+        "numbers": "7|5|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 33,
+                        "prize": "$555"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 118,
+                        "prize": "$88"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 157,
+                        "prize": "$321"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 867,
+                        "prize": "$44"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16648",
+        "winnerCount": 1175
+    },
+    {
+        "drawTime": "20200507183000",
+        "jackpot": [
+            "$550"
+        ],
+        "numbers": "3|7|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 46,
+                        "prize": "$550"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 86,
+                        "prize": "$88"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 162,
+                        "prize": "$319"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 735,
+                        "prize": "$44"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16647",
+        "winnerCount": 1029
+    },
+    {
+        "drawTime": "20200507130000",
+        "jackpot": [
+            "$538"
+        ],
+        "numbers": "5|5|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 52,
+                        "prize": "$538"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 44,
+                        "prize": "$172"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 137,
+                        "prize": "$355"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 342,
+                        "prize": "$86"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16646",
+        "winnerCount": 575
+    },
+    {
+        "drawTime": "20200506183000",
+        "jackpot": [
+            "$545"
+        ],
+        "numbers": "8|3|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 76,
+                        "prize": "$545"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 93,
+                        "prize": "$86"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 110,
+                        "prize": "$316"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 775,
+                        "prize": "$43"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16645",
+        "winnerCount": 1054
+    },
+    {
+        "drawTime": "20200506130000",
+        "jackpot": [
+            "$556"
+        ],
+        "numbers": "2|9|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 28,
+                        "prize": "$556"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 124,
+                        "prize": "$88"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 117,
+                        "prize": "$322"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1099,
+                        "prize": "$44"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16644",
+        "winnerCount": 1368
+    },
+    {
+        "drawTime": "20200505183000",
+        "jackpot": [
+            "$576"
+        ],
+        "numbers": "4|6|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 61,
+                        "prize": "$576"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 71,
+                        "prize": "$92"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 115,
+                        "prize": "$334"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 820,
+                        "prize": "$46"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16643",
+        "winnerCount": 1067
+    },
+    {
+        "drawTime": "20200505130000",
+        "jackpot": [
+            "$431"
+        ],
+        "numbers": "4|0|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 55,
+                        "prize": "$431"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 61,
+                        "prize": "$138"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 204,
+                        "prize": "$284"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 360,
+                        "prize": "$69"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16642",
+        "winnerCount": 680
+    },
+    {
+        "drawTime": "20200504183000",
+        "jackpot": [
+            "$325"
+        ],
+        "numbers": "5|0|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 88,
+                        "prize": "$325"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 170,
+                        "prize": "$52"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 261,
+                        "prize": "$189"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1177,
+                        "prize": "$26"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16641",
+        "winnerCount": 1696
+    },
+    {
+        "drawTime": "20200504130000",
+        "jackpot": [
+            "$530"
+        ],
+        "numbers": "0|8|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 37,
+                        "prize": "$530"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 53,
+                        "prize": "$168"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 164,
+                        "prize": "$350"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 306,
+                        "prize": "$84"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16640",
+        "winnerCount": 560
+    },
+    {
+        "drawTime": "20200503183000",
+        "jackpot": [
+            "$446"
+        ],
+        "numbers": "0|2|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 53,
+                        "prize": "$446"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 122,
+                        "prize": "$70"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 164,
+                        "prize": "$259"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1162,
+                        "prize": "$35"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16639",
+        "winnerCount": 1501
+    },
+    {
+        "drawTime": "20200503130000",
+        "jackpot": [
+            "$677"
+        ],
+        "numbers": "6|0|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 40,
+                        "prize": "$677"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 55,
+                        "prize": "$108"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 123,
+                        "prize": "$393"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 646,
+                        "prize": "$54"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16638",
+        "winnerCount": 864
+    },
+    {
+        "drawTime": "20200502183000",
+        "jackpot": [
+            "$537"
+        ],
+        "numbers": "9|4|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 48,
+                        "prize": "$537"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 116,
+                        "prize": "$84"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 159,
+                        "prize": "$311"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 934,
+                        "prize": "$42"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16637",
+        "winnerCount": 1257
+    },
+    {
+        "drawTime": "20200502130000",
+        "jackpot": [
+            "$471"
+        ],
+        "numbers": "2|3|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 38,
+                        "prize": "$471"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 119,
+                        "prize": "$150"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 158,
+                        "prize": "$310"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 484,
+                        "prize": "$75"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16636",
+        "winnerCount": 799
+    },
+    {
+        "drawTime": "20200501183000",
+        "jackpot": [
+            "$532"
+        ],
+        "numbers": "6|7|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 57,
+                        "prize": "$532"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 140,
+                        "prize": "$84"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 163,
+                        "prize": "$308"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 831,
+                        "prize": "$42"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16635",
+        "winnerCount": 1191
+    },
+    {
+        "drawTime": "20200501130000",
+        "jackpot": [
+            "$452"
+        ],
+        "numbers": "0|4|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 57,
+                        "prize": "$452"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 103,
+                        "prize": "$72"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 219,
+                        "prize": "$262"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 894,
+                        "prize": "$36"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16634",
+        "winnerCount": 1273
+    },
+    {
+        "drawTime": "20200430183000",
+        "jackpot": [
+            "$577"
+        ],
+        "numbers": "7|0|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 33,
+                        "prize": "$577"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 72,
+                        "prize": "$92"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 171,
+                        "prize": "$335"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 717,
+                        "prize": "$46"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16633",
+        "winnerCount": 993
+    },
+    {
+        "drawTime": "20200430130000",
+        "jackpot": [
+            "$531"
+        ],
+        "numbers": "3|1|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 48,
+                        "prize": "$531"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 49,
+                        "prize": "$168"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 143,
+                        "prize": "$350"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 318,
+                        "prize": "$84"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16632",
+        "winnerCount": 558
+    },
+    {
+        "drawTime": "20200429183000",
+        "jackpot": [
+            "$360"
+        ],
+        "numbers": "8|5|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 68,
+                        "prize": "$360"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 71,
+                        "prize": "$114"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 241,
+                        "prize": "$237"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 399,
+                        "prize": "$57"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16631",
+        "winnerCount": 779
+    },
+    {
+        "drawTime": "20200429130000",
+        "jackpot": [
+            "$327"
+        ],
+        "numbers": "8|0|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 69,
+                        "prize": "$327"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 77,
+                        "prize": "$104"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 253,
+                        "prize": "$216"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 377,
+                        "prize": "$52"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16630",
+        "winnerCount": 776
+    },
+    {
+        "drawTime": "20200428183000",
+        "jackpot": [
+            "$678"
+        ],
+        "numbers": "9|4|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 13,
+                        "prize": "$678"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 72,
+                        "prize": "$108"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 123,
+                        "prize": "$393"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 733,
+                        "prize": "$54"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16629",
+        "winnerCount": 941
+    },
+    {
+        "drawTime": "20200428130000",
+        "jackpot": [
+            "$535"
+        ],
+        "numbers": "9|9|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 14,
+                        "prize": "$535"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 48,
+                        "prize": "$170"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 186,
+                        "prize": "$353"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 227,
+                        "prize": "$85"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16628",
+        "winnerCount": 475
+    },
+    {
+        "drawTime": "20200427183000",
+        "jackpot": [
+            "$439"
+        ],
+        "numbers": "4|8|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 43,
+                        "prize": "$439"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 87,
+                        "prize": "$70"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 204,
+                        "prize": "$254"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 738,
+                        "prize": "$35"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16627",
+        "winnerCount": 1072
+    },
+    {
+        "drawTime": "20200427130000",
+        "jackpot": [
+            "$497"
+        ],
+        "numbers": "2|8|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 26,
+                        "prize": "$497"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 49,
+                        "prize": "$158"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 152,
+                        "prize": "$328"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 335,
+                        "prize": "$79"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16626",
+        "winnerCount": 562
+    },
+    {
+        "drawTime": "20200426183000",
+        "jackpot": [
+            "$560"
+        ],
+        "numbers": "8|3|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 39,
+                        "prize": "$560"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 74,
+                        "prize": "$88"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 122,
+                        "prize": "$325"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 704,
+                        "prize": "$44"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16625",
+        "winnerCount": 939
+    },
+    {
+        "drawTime": "20200426130000",
+        "jackpot": [
+            "$578"
+        ],
+        "numbers": "9|4|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 18,
+                        "prize": "$578"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 43,
+                        "prize": "$184"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 138,
+                        "prize": "$382"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 314,
+                        "prize": "$92"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16624",
+        "winnerCount": 513
+    },
+    {
+        "drawTime": "20200425183000",
+        "jackpot": [
+            "$609"
+        ],
+        "numbers": "1|5|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 23,
+                        "prize": "$609"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 48,
+                        "prize": "$194"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 132,
+                        "prize": "$402"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 332,
+                        "prize": "$97"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16623",
+        "winnerCount": 535
+    },
+    {
+        "drawTime": "20200425130000",
+        "jackpot": [
+            "$478"
+        ],
+        "numbers": "1|5|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 34,
+                        "prize": "$478"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 138,
+                        "prize": "$76"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 115,
+                        "prize": "$277"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1199,
+                        "prize": "$38"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16622",
+        "winnerCount": 1486
+    },
+    {
+        "drawTime": "20200424183000",
+        "jackpot": [
+            "$535"
+        ],
+        "numbers": "4|9|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 34,
+                        "prize": "$535"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 107,
+                        "prize": "$84"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 131,
+                        "prize": "$310"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1005,
+                        "prize": "$42"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16621",
+        "winnerCount": 1277
+    },
+    {
+        "drawTime": "20200424130000",
+        "jackpot": [
+            "$674"
+        ],
+        "numbers": "2|7|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 13,
+                        "prize": "$674"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 50,
+                        "prize": "$214"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 100,
+                        "prize": "$445"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 378,
+                        "prize": "$107"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16620",
+        "winnerCount": 541
+    },
+    {
+        "drawTime": "20200423183000",
+        "jackpot": [
+            "$591"
+        ],
+        "numbers": "1|4|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 26,
+                        "prize": "$591"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 98,
+                        "prize": "$94"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 119,
+                        "prize": "$342"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 836,
+                        "prize": "$47"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16619",
+        "winnerCount": 1079
+    },
+    {
+        "drawTime": "20200423130000",
+        "jackpot": [
+            "$511"
+        ],
+        "numbers": "4|4|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 27,
+                        "prize": "$511"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 42,
+                        "prize": "$162"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 173,
+                        "prize": "$337"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 284,
+                        "prize": "$81"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16618",
+        "winnerCount": 526
+    },
+    {
+        "drawTime": "20200422183000",
+        "jackpot": [
+            "$647"
+        ],
+        "numbers": "3|4|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 23,
+                        "prize": "$647"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 42,
+                        "prize": "$206"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 124,
+                        "prize": "$427"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 272,
+                        "prize": "$103"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16617",
+        "winnerCount": 461
+    },
+    {
+        "drawTime": "20200422130000",
+        "jackpot": [
+            "$153"
+        ],
+        "numbers": "4|2|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 213,
+                        "prize": "$153"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 121,
+                        "prize": "$48"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 472,
+                        "prize": "$101"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 605,
+                        "prize": "$24"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16616",
+        "winnerCount": 1411
+    },
+    {
+        "drawTime": "20200421183000",
+        "jackpot": [
+            "$538"
+        ],
+        "numbers": "4|0|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 31,
+                        "prize": "$538"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 101,
+                        "prize": "$86"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 133,
+                        "prize": "$312"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 873,
+                        "prize": "$43"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16615",
+        "winnerCount": 1138
+    },
+    {
+        "drawTime": "20200421130000",
+        "jackpot": [
+            "$519"
+        ],
+        "numbers": "0|8|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 45,
+                        "prize": "$519"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 93,
+                        "prize": "$82"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 105,
+                        "prize": "$301"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 862,
+                        "prize": "$41"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16614",
+        "winnerCount": 1105
+    },
+    {
+        "drawTime": "20200420183000",
+        "jackpot": [
+            "$628"
+        ],
+        "numbers": "3|4|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 26,
+                        "prize": "$628"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 45,
+                        "prize": "$200"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 120,
+                        "prize": "$414"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 282,
+                        "prize": "$100"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16613",
+        "winnerCount": 473
+    },
+    {
+        "drawTime": "20200420130000",
+        "jackpot": [
+            "$544"
+        ],
+        "numbers": "2|1|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 37,
+                        "prize": "$544"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 64,
+                        "prize": "$86"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 145,
+                        "prize": "$315"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 542,
+                        "prize": "$43"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16612",
+        "winnerCount": 788
+    },
+    {
+        "drawTime": "20200419183000",
+        "jackpot": [
+            "$436"
+        ],
+        "numbers": "6|7|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 63,
+                        "prize": "$436"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 85,
+                        "prize": "$68"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 159,
+                        "prize": "$252"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 776,
+                        "prize": "$34"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16611",
+        "winnerCount": 1083
+    },
+    {
+        "drawTime": "20200419130000",
+        "jackpot": [
+            "$514"
+        ],
+        "numbers": "5|5|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 28,
+                        "prize": "$514"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 52,
+                        "prize": "$164"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 139,
+                        "prize": "$339"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 357,
+                        "prize": "$82"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16610",
+        "winnerCount": 576
+    },
+    {
+        "drawTime": "20200418183000",
+        "jackpot": [
+            "$399"
+        ],
+        "numbers": "1|0|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 45,
+                        "prize": "$399"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 77,
+                        "prize": "$62"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 269,
+                        "prize": "$231"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 842,
+                        "prize": "$31"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16609",
+        "winnerCount": 1233
+    },
+    {
+        "drawTime": "20200418130000",
+        "jackpot": [
+            "$448"
+        ],
+        "numbers": "2|2|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 32,
+                        "prize": "$448"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 42,
+                        "prize": "$142"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 225,
+                        "prize": "$295"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 249,
+                        "prize": "$71"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16608",
+        "winnerCount": 548
+    },
+    {
+        "drawTime": "20200417183000",
+        "jackpot": [
+            "$615"
+        ],
+        "numbers": "9|5|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 26,
+                        "prize": "$615"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 68,
+                        "prize": "$98"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 153,
+                        "prize": "$356"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 708,
+                        "prize": "$49"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16607",
+        "winnerCount": 955
+    },
+    {
+        "drawTime": "20200417130000",
+        "jackpot": [
+            "$481"
+        ],
+        "numbers": "7|6|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 35,
+                        "prize": "$481"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 59,
+                        "prize": "$154"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 153,
+                        "prize": "$317"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 395,
+                        "prize": "$77"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16606",
+        "winnerCount": 642
+    },
+    {
+        "drawTime": "20200416183000",
+        "jackpot": [
+            "$410"
+        ],
+        "numbers": "3|1|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 71,
+                        "prize": "$410"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 105,
+                        "prize": "$64"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 213,
+                        "prize": "$238"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 675,
+                        "prize": "$32"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16605",
+        "winnerCount": 1064
+    },
+    {
+        "drawTime": "20200416130000",
+        "jackpot": [
+            "$437"
+        ],
+        "numbers": "7|3|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 51,
+                        "prize": "$437"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 98,
+                        "prize": "$68"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 209,
+                        "prize": "$253"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 605,
+                        "prize": "$34"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16604",
+        "winnerCount": 963
+    },
+    {
+        "drawTime": "20200415183000",
+        "jackpot": [
+            "$456"
+        ],
+        "numbers": "3|6|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 48,
+                        "prize": "$456"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 78,
+                        "prize": "$72"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 206,
+                        "prize": "$264"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 726,
+                        "prize": "$36"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16603",
+        "winnerCount": 1058
+    },
+    {
+        "drawTime": "20200415130000",
+        "jackpot": [
+            "$683"
+        ],
+        "numbers": "6|5|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 12,
+                        "prize": "$683"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 75,
+                        "prize": "$108"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 124,
+                        "prize": "$396"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 671,
+                        "prize": "$54"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16602",
+        "winnerCount": 882
+    },
+    {
+        "drawTime": "20200414183000",
+        "jackpot": [
+            "$333"
+        ],
+        "numbers": "4|0|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 69,
+                        "prize": "$333"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 86,
+                        "prize": "$52"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 242,
+                        "prize": "$193"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 910,
+                        "prize": "$26"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16601",
+        "winnerCount": 1307
+    },
+    {
+        "drawTime": "20200414130000",
+        "jackpot": [
+            "$434"
+        ],
+        "numbers": "8|0|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 38,
+                        "prize": "$434"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 70,
+                        "prize": "$68"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 172,
+                        "prize": "$251"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 765,
+                        "prize": "$34"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16600",
+        "winnerCount": 1045
+    },
+    {
+        "drawTime": "20200413183000",
+        "jackpot": [
+            "$423"
+        ],
+        "numbers": "3|2|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 49,
+                        "prize": "$423"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 87,
+                        "prize": "$66"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 195,
+                        "prize": "$245"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 613,
+                        "prize": "$33"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16599",
+        "winnerCount": 944
+    },
+    {
+        "drawTime": "20200413130000",
+        "jackpot": [
+            "$601"
+        ],
+        "numbers": "8|8|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 18,
+                        "prize": "$601"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 49,
+                        "prize": "$192"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 114,
+                        "prize": "$397"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 233,
+                        "prize": "$96"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16598",
+        "winnerCount": 414
+    },
+    {
+        "drawTime": "20200412183000",
+        "jackpot": [
+            "$458"
+        ],
+        "numbers": "0|5|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 40,
+                        "prize": "$458"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 81,
+                        "prize": "$72"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 142,
+                        "prize": "$266"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 721,
+                        "prize": "$36"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16597",
+        "winnerCount": 984
+    },
+    {
+        "drawTime": "20200412130000",
+        "jackpot": [
+            "$741"
+        ],
+        "numbers": "9|0|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 24,
+                        "prize": "$741"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 53,
+                        "prize": "$118"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 75,
+                        "prize": "$430"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 530,
+                        "prize": "$59"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16596",
+        "winnerCount": 682
+    },
+    {
+        "drawTime": "20200411183000",
+        "jackpot": [
+            "$401"
+        ],
+        "numbers": "5|2|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 64,
+                        "prize": "$401"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 133,
+                        "prize": "$64"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 195,
+                        "prize": "$232"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 637,
+                        "prize": "$32"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16595",
+        "winnerCount": 1029
+    },
+    {
+        "drawTime": "20200411130000",
+        "jackpot": [
+            "$512"
+        ],
+        "numbers": "8|0|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 35,
+                        "prize": "$512"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 52,
+                        "prize": "$162"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 144,
+                        "prize": "$338"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 245,
+                        "prize": "$81"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16594",
+        "winnerCount": 476
+    },
+    {
+        "drawTime": "20200410183000",
+        "jackpot": [
+            "$724"
+        ],
+        "numbers": "2|8|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 18,
+                        "prize": "$724"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 77,
+                        "prize": "$114"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 93,
+                        "prize": "$420"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 695,
+                        "prize": "$57"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16593",
+        "winnerCount": 883
+    },
+    {
+        "drawTime": "20200410130000",
+        "jackpot": [
+            "$459"
+        ],
+        "numbers": "7|8|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 44,
+                        "prize": "$459"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 112,
+                        "prize": "$72"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 146,
+                        "prize": "$266"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 667,
+                        "prize": "$36"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16592",
+        "winnerCount": 969
+    },
+    {
+        "drawTime": "20200409183000",
+        "jackpot": [
+            "$635"
+        ],
+        "numbers": "2|9|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 27,
+                        "prize": "$635"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 89,
+                        "prize": "$100"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 92,
+                        "prize": "$368"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 604,
+                        "prize": "$50"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16591",
+        "winnerCount": 812
+    },
+    {
+        "drawTime": "20200409130000",
+        "jackpot": [
+            "$257"
+        ],
+        "numbers": "4|4|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 346,
+                        "prize": "$257"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 0,
+                        "prize": "Free play"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 0,
+                        "prize": "Free play"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 0,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16590",
+        "winnerCount": 346
+    },
+    {
+        "drawTime": "20200408183000",
+        "jackpot": [
+            "$486"
+        ],
+        "numbers": "6|0|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 45,
+                        "prize": "$486"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 54,
+                        "prize": "$76"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 162,
+                        "prize": "$282"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 625,
+                        "prize": "$38"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16589",
+        "winnerCount": 886
+    },
+    {
+        "drawTime": "20200408130000",
+        "jackpot": [
+            "$465"
+        ],
+        "numbers": "0|0|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 28,
+                        "prize": "$465"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 36,
+                        "prize": "$148"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 162,
+                        "prize": "$307"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 288,
+                        "prize": "$74"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16588",
+        "winnerCount": 514
+    },
+    {
+        "drawTime": "20200407183000",
+        "jackpot": [
+            "$794"
+        ],
+        "numbers": "0|9|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 19,
+                        "prize": "$794"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 54,
+                        "prize": "$126"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 73,
+                        "prize": "$460"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 598,
+                        "prize": "$63"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16587",
+        "winnerCount": 744
+    },
+    {
+        "drawTime": "20200407130000",
+        "jackpot": [
+            "$359"
+        ],
+        "numbers": "1|0|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 51,
+                        "prize": "$359"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 111,
+                        "prize": "$56"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 208,
+                        "prize": "$208"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 777,
+                        "prize": "$28"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16586",
+        "winnerCount": 1147
+    },
+    {
+        "drawTime": "20200406183000",
+        "jackpot": [
+            "$683"
+        ],
+        "numbers": "0|1|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 15,
+                        "prize": "$683"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 90,
+                        "prize": "$108"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 99,
+                        "prize": "$396"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 626,
+                        "prize": "$54"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16585",
+        "winnerCount": 830
+    },
+    {
+        "drawTime": "20200406130000",
+        "jackpot": [
+            "$527"
+        ],
+        "numbers": "3|0|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 40,
+                        "prize": "$527"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 84,
+                        "prize": "$84"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 120,
+                        "prize": "$305"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 500,
+                        "prize": "$42"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16584",
+        "winnerCount": 744
+    },
+    {
+        "drawTime": "20200405183000",
+        "jackpot": [
+            "$540"
+        ],
+        "numbers": "9|5|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 28,
+                        "prize": "$540"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 105,
+                        "prize": "$86"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 127,
+                        "prize": "$313"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 688,
+                        "prize": "$43"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16583",
+        "winnerCount": 948
+    },
+    {
+        "drawTime": "20200405130000",
+        "jackpot": [
+            "$425"
+        ],
+        "numbers": "4|4|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 51,
+                        "prize": "$425"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 45,
+                        "prize": "$136"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 181,
+                        "prize": "$280"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 212,
+                        "prize": "$68"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16582",
+        "winnerCount": 489
+    },
+    {
+        "drawTime": "20200404183000",
+        "jackpot": [
+            "$576"
+        ],
+        "numbers": "1|4|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 26,
+                        "prize": "$576"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 104,
+                        "prize": "$92"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 137,
+                        "prize": "$334"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 728,
+                        "prize": "$46"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16581",
+        "winnerCount": 995
+    },
+    {
+        "drawTime": "20200404130000",
+        "jackpot": [
+            "$683"
+        ],
+        "numbers": "4|5|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 26,
+                        "prize": "$683"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 101,
+                        "prize": "$108"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 90,
+                        "prize": "$396"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 641,
+                        "prize": "$54"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16580",
+        "winnerCount": 858
+    },
+    {
+        "drawTime": "20200403183000",
+        "jackpot": [
+            "$361"
+        ],
+        "numbers": "4|0|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 55,
+                        "prize": "$361"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 126,
+                        "prize": "$56"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 267,
+                        "prize": "$209"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 837,
+                        "prize": "$28"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16579",
+        "winnerCount": 1285
+    },
+    {
+        "drawTime": "20200403130000",
+        "jackpot": [
+            "$725"
+        ],
+        "numbers": "3|7|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 19,
+                        "prize": "$725"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 33,
+                        "prize": "$232"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 106,
+                        "prize": "$478"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 253,
+                        "prize": "$116"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16578",
+        "winnerCount": 411
+    },
+    {
+        "drawTime": "20200402183000",
+        "jackpot": [
+            "$493"
+        ],
+        "numbers": "6|2|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 42,
+                        "prize": "$493"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 58,
+                        "prize": "$78"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 172,
+                        "prize": "$286"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 672,
+                        "prize": "$39"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16577",
+        "winnerCount": 944
+    },
+    {
+        "drawTime": "20200402130000",
+        "jackpot": [
+            "$589"
+        ],
+        "numbers": "2|2|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 31,
+                        "prize": "$589"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 39,
+                        "prize": "$188"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 124,
+                        "prize": "$389"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 221,
+                        "prize": "$94"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16576",
+        "winnerCount": 415
+    },
+    {
+        "drawTime": "20200401183000",
+        "jackpot": [
+            "$549"
+        ],
+        "numbers": "3|4|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 32,
+                        "prize": "$549"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 75,
+                        "prize": "$86"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 152,
+                        "prize": "$318"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 611,
+                        "prize": "$43"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16575",
+        "winnerCount": 870
+    },
+    {
+        "drawTime": "20200401130000",
+        "jackpot": [
+            "$560"
+        ],
+        "numbers": "3|8|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 36,
+                        "prize": "$560"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 23,
+                        "prize": "$178"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 131,
+                        "prize": "$369"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 257,
+                        "prize": "$89"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16574",
+        "winnerCount": 447
+    },
+    {
+        "drawTime": "20200331183000",
+        "jackpot": [
+            "$443"
+        ],
+        "numbers": "9|2|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 30,
+                        "prize": "$443"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 48,
+                        "prize": "$140"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 161,
+                        "prize": "$292"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 381,
+                        "prize": "$70"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16573",
+        "winnerCount": 620
+    },
+    {
+        "drawTime": "20200331130000",
+        "jackpot": [
+            "$530"
+        ],
+        "numbers": "2|9|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 31,
+                        "prize": "$530"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 81,
+                        "prize": "$84"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 98,
+                        "prize": "$307"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 814,
+                        "prize": "$42"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16572",
+        "winnerCount": 1024
+    },
+    {
+        "drawTime": "20200330183000",
+        "jackpot": [
+            "$669"
+        ],
+        "numbers": "4|8|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 17,
+                        "prize": "$669"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 70,
+                        "prize": "$106"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 80,
+                        "prize": "$388"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 751,
+                        "prize": "$53"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16571",
+        "winnerCount": 918
+    },
+    {
+        "drawTime": "20200330130000",
+        "jackpot": [
+            "$647"
+        ],
+        "numbers": "9|8|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 12,
+                        "prize": "$647"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 35,
+                        "prize": "$206"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 92,
+                        "prize": "$427"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 284,
+                        "prize": "$103"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16570",
+        "winnerCount": 423
+    },
+    {
+        "drawTime": "20200329183000",
+        "jackpot": [
+            "$759"
+        ],
+        "numbers": "7|8|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 27,
+                        "prize": "$759"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 54,
+                        "prize": "$120"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 70,
+                        "prize": "$440"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 526,
+                        "prize": "$60"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16569",
+        "winnerCount": 677
+    },
+    {
+        "drawTime": "20200329130000",
+        "jackpot": [
+            "$422"
+        ],
+        "numbers": "1|1|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 58,
+                        "prize": "$422"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 45,
+                        "prize": "$134"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 159,
+                        "prize": "$278"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 206,
+                        "prize": "$67"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16568",
+        "winnerCount": 468
+    },
+    {
+        "drawTime": "20200328183000",
+        "jackpot": [
+            "$455"
+        ],
+        "numbers": "9|6|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 35,
+                        "prize": "$455"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 37,
+                        "prize": "$144"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 171,
+                        "prize": "$300"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 333,
+                        "prize": "$72"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16567",
+        "winnerCount": 576
+    },
+    {
+        "drawTime": "20200328130000",
+        "jackpot": [
+            "$577"
+        ],
+        "numbers": "4|9|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 17,
+                        "prize": "$577"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 44,
+                        "prize": "$184"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 126,
+                        "prize": "$380"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 308,
+                        "prize": "$92"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16566",
+        "winnerCount": 495
+    },
+    {
+        "drawTime": "20200327183000",
+        "jackpot": [
+            "$643"
+        ],
+        "numbers": "6|7|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 19,
+                        "prize": "$643"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 86,
+                        "prize": "$102"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 120,
+                        "prize": "$373"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 673,
+                        "prize": "$51"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16565",
+        "winnerCount": 898
+    },
+    {
+        "drawTime": "20200327130000",
+        "jackpot": [
+            "$479"
+        ],
+        "numbers": "7|1|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 26,
+                        "prize": "$479"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 91,
+                        "prize": "$76"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 170,
+                        "prize": "$277"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 682,
+                        "prize": "$38"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16564",
+        "winnerCount": 969
+    },
+    {
+        "drawTime": "20200326183000",
+        "jackpot": [
+            "$519"
+        ],
+        "numbers": "5|3|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 47,
+                        "prize": "$519"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 85,
+                        "prize": "$82"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 110,
+                        "prize": "$301"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 760,
+                        "prize": "$41"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16563",
+        "winnerCount": 1002
+    },
+    {
+        "drawTime": "20200326130000",
+        "jackpot": [
+            "$413"
+        ],
+        "numbers": "7|1|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 53,
+                        "prize": "$413"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 76,
+                        "prize": "$66"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 184,
+                        "prize": "$239"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 617,
+                        "prize": "$33"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16562",
+        "winnerCount": 930
+    },
+    {
+        "drawTime": "20200325183000",
+        "jackpot": [
+            "$473"
+        ],
+        "numbers": "1|3|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 48,
+                        "prize": "$473"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 91,
+                        "prize": "$74"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 135,
+                        "prize": "$274"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 755,
+                        "prize": "$37"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16561",
+        "winnerCount": 1029
+    },
+    {
+        "drawTime": "20200325130000",
+        "jackpot": [
+            "$398"
+        ],
+        "numbers": "6|4|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 34,
+                        "prize": "$398"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 105,
+                        "prize": "$62"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 179,
+                        "prize": "$231"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 854,
+                        "prize": "$31"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16560",
+        "winnerCount": 1172
+    },
+    {
+        "drawTime": "20200324183000",
+        "jackpot": [
+            "$463"
+        ],
+        "numbers": "2|5|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 40,
+                        "prize": "$463"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 108,
+                        "prize": "$74"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 153,
+                        "prize": "$269"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 647,
+                        "prize": "$37"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16559",
+        "winnerCount": 948
+    },
+    {
+        "drawTime": "20200324130000",
+        "jackpot": [
+            "$697"
+        ],
+        "numbers": "3|5|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 14,
+                        "prize": "$697"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 40,
+                        "prize": "$222"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 101,
+                        "prize": "$460"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 198,
+                        "prize": "$111"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16558",
+        "winnerCount": 353
+    },
+    {
+        "drawTime": "20200323183000",
+        "jackpot": [
+            "$478"
+        ],
+        "numbers": "3|6|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 26,
+                        "prize": "$478"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 76,
+                        "prize": "$76"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 162,
+                        "prize": "$277"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 677,
+                        "prize": "$38"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16557",
+        "winnerCount": 941
+    },
+    {
+        "drawTime": "20200323130000",
+        "jackpot": [
+            "$390"
+        ],
+        "numbers": "0|3|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 33,
+                        "prize": "$390"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 37,
+                        "prize": "$124"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 180,
+                        "prize": "$257"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 350,
+                        "prize": "$62"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16556",
+        "winnerCount": 600
+    },
+    {
+        "drawTime": "20200322183000",
+        "jackpot": [
+            "$308"
+        ],
+        "numbers": "4|2|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 74,
+                        "prize": "$308"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 135,
+                        "prize": "$48"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 213,
+                        "prize": "$178"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 864,
+                        "prize": "$24"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16555",
+        "winnerCount": 1286
+    },
+    {
+        "drawTime": "20200322130000",
+        "jackpot": [
+            "$567"
+        ],
+        "numbers": "3|8|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 20,
+                        "prize": "$567"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 93,
+                        "prize": "$90"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 104,
+                        "prize": "$329"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 792,
+                        "prize": "$45"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16554",
+        "winnerCount": 1009
+    },
+    {
+        "drawTime": "20200321183000",
+        "jackpot": [
+            "$493"
+        ],
+        "numbers": "1|3|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 35,
+                        "prize": "$493"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 105,
+                        "prize": "$78"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 158,
+                        "prize": "$285"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 705,
+                        "prize": "$39"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16553",
+        "winnerCount": 1003
+    },
+    {
+        "drawTime": "20200321130000",
+        "jackpot": [
+            "$281"
+        ],
+        "numbers": "8|0|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 125,
+                        "prize": "$281"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 118,
+                        "prize": "$44"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 222,
+                        "prize": "$163"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 823,
+                        "prize": "$22"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16552",
+        "winnerCount": 1288
+    },
+    {
+        "drawTime": "20200320183000",
+        "jackpot": [
+            "$708"
+        ],
+        "numbers": "2|9|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 14,
+                        "prize": "$708"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 79,
+                        "prize": "$112"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 92,
+                        "prize": "$410"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 779,
+                        "prize": "$56"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16551",
+        "winnerCount": 964
+    },
+    {
+        "drawTime": "20200320130000",
+        "jackpot": [
+            "$510"
+        ],
+        "numbers": "7|2|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 36,
+                        "prize": "$510"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 77,
+                        "prize": "$80"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 146,
+                        "prize": "$296"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 623,
+                        "prize": "$40"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16550",
+        "winnerCount": 882
+    },
+    {
+        "drawTime": "20200319183000",
+        "jackpot": [
+            "$483"
+        ],
+        "numbers": "0|0|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 37,
+                        "prize": "$483"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 48,
+                        "prize": "$154"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 145,
+                        "prize": "$319"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 340,
+                        "prize": "$77"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16549",
+        "winnerCount": 570
+    },
+    {
+        "drawTime": "20200319130000",
+        "jackpot": [
+            "$480"
+        ],
+        "numbers": "7|7|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 25,
+                        "prize": "$480"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 57,
+                        "prize": "$152"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 157,
+                        "prize": "$317"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 315,
+                        "prize": "$76"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16548",
+        "winnerCount": 554
+    },
+    {
+        "drawTime": "20200318183000",
+        "jackpot": [
+            "$764"
+        ],
+        "numbers": "4|3|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 28,
+                        "prize": "$764"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 57,
+                        "prize": "$122"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 95,
+                        "prize": "$443"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 451,
+                        "prize": "$61"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16547",
+        "winnerCount": 631
+    },
+    {
+        "drawTime": "20200318130000",
+        "jackpot": [
+            "$387"
+        ],
+        "numbers": "7|5|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 63,
+                        "prize": "$387"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 154,
+                        "prize": "$62"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 138,
+                        "prize": "$224"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 891,
+                        "prize": "$31"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16546",
+        "winnerCount": 1246
+    },
+    {
+        "drawTime": "20200317183000",
+        "jackpot": [
+            "$660"
+        ],
+        "numbers": "2|5|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 19,
+                        "prize": "$660"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 62,
+                        "prize": "$210"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 104,
+                        "prize": "$435"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 250,
+                        "prize": "$105"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16545",
+        "winnerCount": 435
+    },
+    {
+        "drawTime": "20200317130000",
+        "jackpot": [
+            "$341"
+        ],
+        "numbers": "0|8|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 141,
+                        "prize": "$341"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 65,
+                        "prize": "$54"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 109,
+                        "prize": "$197"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 730,
+                        "prize": "$27"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16544",
+        "winnerCount": 1045
+    },
+    {
+        "drawTime": "20200316183000",
+        "jackpot": [
+            "$578"
+        ],
+        "numbers": "7|4|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 23,
+                        "prize": "$578"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 66,
+                        "prize": "$92"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 142,
+                        "prize": "$335"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 634,
+                        "prize": "$46"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16543",
+        "winnerCount": 865
+    },
+    {
+        "drawTime": "20200316130000",
+        "jackpot": [
+            "$498"
+        ],
+        "numbers": "9|6|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 30,
+                        "prize": "$498"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 88,
+                        "prize": "$78"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 126,
+                        "prize": "$289"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 867,
+                        "prize": "$39"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16542",
+        "winnerCount": 1111
+    },
+    {
+        "drawTime": "20200315183000",
+        "jackpot": [
+            "$439"
+        ],
+        "numbers": "6|2|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 40,
+                        "prize": "$439"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 63,
+                        "prize": "$70"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 190,
+                        "prize": "$254"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 925,
+                        "prize": "$35"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16541",
+        "winnerCount": 1218
+    },
+    {
+        "drawTime": "20200315130000",
+        "jackpot": [
+            "$507"
+        ],
+        "numbers": "1|6|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 29,
+                        "prize": "$507"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 109,
+                        "prize": "$80"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 134,
+                        "prize": "$294"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 944,
+                        "prize": "$40"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16540",
+        "winnerCount": 1216
+    },
+    {
+        "drawTime": "20200314183000",
+        "jackpot": [
+            "$442"
+        ],
+        "numbers": "6|1|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 52,
+                        "prize": "$442"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 74,
+                        "prize": "$140"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 190,
+                        "prize": "$291"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 301,
+                        "prize": "$70"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16539",
+        "winnerCount": 617
+    },
+    {
+        "drawTime": "20200314130000",
+        "jackpot": [
+            "$558"
+        ],
+        "numbers": "2|0|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 23,
+                        "prize": "$558"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 56,
+                        "prize": "$88"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 175,
+                        "prize": "$323"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 724,
+                        "prize": "$44"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16538",
+        "winnerCount": 978
+    },
+    {
+        "drawTime": "20200313183000",
+        "jackpot": [
+            "$411"
+        ],
+        "numbers": "1|0|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 60,
+                        "prize": "$411"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 131,
+                        "prize": "$64"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 213,
+                        "prize": "$238"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 930,
+                        "prize": "$32"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16537",
+        "winnerCount": 1334
+    },
+    {
+        "drawTime": "20200313130000",
+        "jackpot": [
+            "$659"
+        ],
+        "numbers": "1|7|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 32,
+                        "prize": "$659"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 98,
+                        "prize": "$104"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 103,
+                        "prize": "$382"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 701,
+                        "prize": "$52"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16536",
+        "winnerCount": 934
+    },
+    {
+        "drawTime": "20200312183000",
+        "jackpot": [
+            "$441"
+        ],
+        "numbers": "8|5|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 58,
+                        "prize": "$441"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 118,
+                        "prize": "$70"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 160,
+                        "prize": "$256"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 884,
+                        "prize": "$35"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16535",
+        "winnerCount": 1220
+    },
+    {
+        "drawTime": "20200312130000",
+        "jackpot": [
+            "$585"
+        ],
+        "numbers": "5|6|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 28,
+                        "prize": "$585"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 69,
+                        "prize": "$92"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 135,
+                        "prize": "$339"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 724,
+                        "prize": "$46"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16534",
+        "winnerCount": 956
+    },
+    {
+        "drawTime": "20200311183000",
+        "jackpot": [
+            "$473"
+        ],
+        "numbers": "2|1|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 52,
+                        "prize": "$473"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 110,
+                        "prize": "$74"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 166,
+                        "prize": "$274"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 824,
+                        "prize": "$37"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16533",
+        "winnerCount": 1152
+    },
+    {
+        "drawTime": "20200311130000",
+        "jackpot": [
+            "$663"
+        ],
+        "numbers": "2|7|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 31,
+                        "prize": "$663"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 82,
+                        "prize": "$106"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 109,
+                        "prize": "$384"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 659,
+                        "prize": "$53"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16532",
+        "winnerCount": 881
+    },
+    {
+        "drawTime": "20200310183000",
+        "jackpot": [
+            "$469"
+        ],
+        "numbers": "3|4|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 65,
+                        "prize": "$469"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 126,
+                        "prize": "$74"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 158,
+                        "prize": "$272"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 673,
+                        "prize": "$37"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16531",
+        "winnerCount": 1022
+    },
+    {
+        "drawTime": "20200310130000",
+        "jackpot": [
+            "$569"
+        ],
+        "numbers": "5|1|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 33,
+                        "prize": "$569"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 43,
+                        "prize": "$182"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 145,
+                        "prize": "$375"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 234,
+                        "prize": "$91"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16530",
+        "winnerCount": 455
+    },
+    {
+        "drawTime": "20200309183000",
+        "jackpot": [
+            "$667"
+        ],
+        "numbers": "6|8|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 31,
+                        "prize": "$667"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 43,
+                        "prize": "$212"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 106,
+                        "prize": "$440"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 288,
+                        "prize": "$106"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16529",
+        "winnerCount": 468
+    },
+    {
+        "drawTime": "20200309130000",
+        "jackpot": [
+            "$286"
+        ],
+        "numbers": "4|4|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 358,
+                        "prize": "$286"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 0,
+                        "prize": "Free play"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 0,
+                        "prize": "Free play"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 0,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16528",
+        "winnerCount": 358
+    },
+    {
+        "drawTime": "20200308183000",
+        "jackpot": [
+            "$416"
+        ],
+        "numbers": "2|8|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 75,
+                        "prize": "$416"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 90,
+                        "prize": "$66"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 184,
+                        "prize": "$241"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 698,
+                        "prize": "$33"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16527",
+        "winnerCount": 1047
+    },
+    {
+        "drawTime": "20200308130000",
+        "jackpot": [
+            "$581"
+        ],
+        "numbers": "7|5|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 25,
+                        "prize": "$581"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 82,
+                        "prize": "$92"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 135,
+                        "prize": "$337"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 729,
+                        "prize": "$46"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16526",
+        "winnerCount": 971
+    },
+    {
+        "drawTime": "20200307183000",
+        "jackpot": [
+            "$541"
+        ],
+        "numbers": "7|6|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 30,
+                        "prize": "$541"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 40,
+                        "prize": "$172"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 187,
+                        "prize": "$357"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 329,
+                        "prize": "$86"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16525",
+        "winnerCount": 586
+    },
+    {
+        "drawTime": "20200307130000",
+        "jackpot": [
+            "$629"
+        ],
+        "numbers": "8|6|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 24,
+                        "prize": "$629"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 78,
+                        "prize": "$100"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 148,
+                        "prize": "$365"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 787,
+                        "prize": "$50"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16524",
+        "winnerCount": 1037
+    },
+    {
+        "drawTime": "20200306183000",
+        "jackpot": [
+            "$591"
+        ],
+        "numbers": "7|6|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 47,
+                        "prize": "$591"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 106,
+                        "prize": "$94"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 135,
+                        "prize": "$343"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 853,
+                        "prize": "$47"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16523",
+        "winnerCount": 1141
+    },
+    {
+        "drawTime": "20200306130000",
+        "jackpot": [
+            "$577"
+        ],
+        "numbers": "2|9|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 38,
+                        "prize": "$577"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 121,
+                        "prize": "$92"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 118,
+                        "prize": "$335"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1050,
+                        "prize": "$46"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16522",
+        "winnerCount": 1327
+    },
+    {
+        "drawTime": "20200305183000",
+        "jackpot": [
+            "$470"
+        ],
+        "numbers": "0|4|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 78,
+                        "prize": "$470"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 83,
+                        "prize": "$74"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 172,
+                        "prize": "$272"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 730,
+                        "prize": "$37"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16521",
+        "winnerCount": 1063
+    },
+    {
+        "drawTime": "20200305130000",
+        "jackpot": [
+            "$522"
+        ],
+        "numbers": "1|0|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 32,
+                        "prize": "$522"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 96,
+                        "prize": "$82"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 202,
+                        "prize": "$303"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 683,
+                        "prize": "$41"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16520",
+        "winnerCount": 1013
+    },
+    {
+        "drawTime": "20200304183000",
+        "jackpot": [
+            "$340"
+        ],
+        "numbers": "7|1|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 55,
+                        "prize": "$340"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 66,
+                        "prize": "$108"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 326,
+                        "prize": "$224"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 338,
+                        "prize": "$54"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16519",
+        "winnerCount": 785
+    },
+    {
+        "drawTime": "20200304130000",
+        "jackpot": [
+            "$616"
+        ],
+        "numbers": "8|5|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 29,
+                        "prize": "$616"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 95,
+                        "prize": "$98"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 150,
+                        "prize": "$357"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 641,
+                        "prize": "$49"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16518",
+        "winnerCount": 915
+    },
+    {
+        "drawTime": "20200303183000",
+        "jackpot": [
+            "$327"
+        ],
+        "numbers": "9|1|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 108,
+                        "prize": "$327"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 47,
+                        "prize": "$104"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 291,
+                        "prize": "$216"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 267,
+                        "prize": "$52"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16517",
+        "winnerCount": 713
+    },
+    {
+        "drawTime": "20200303130000",
+        "jackpot": [
+            "$468"
+        ],
+        "numbers": "6|6|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 34,
+                        "prize": "$468"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 49,
+                        "prize": "$150"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 215,
+                        "prize": "$309"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 364,
+                        "prize": "$75"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16516",
+        "winnerCount": 662
+    },
+    {
+        "drawTime": "20200302183000",
+        "jackpot": [
+            "$679"
+        ],
+        "numbers": "0|3|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 24,
+                        "prize": "$679"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 105,
+                        "prize": "$108"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 112,
+                        "prize": "$394"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 788,
+                        "prize": "$54"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16515",
+        "winnerCount": 1029
+    },
+    {
+        "drawTime": "20200302130000",
+        "jackpot": [
+            "$549"
+        ],
+        "numbers": "6|1|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 50,
+                        "prize": "$549"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 73,
+                        "prize": "$86"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 156,
+                        "prize": "$318"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 589,
+                        "prize": "$43"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16514",
+        "winnerCount": 868
+    },
+    {
+        "drawTime": "20200301183000",
+        "jackpot": [
+            "$456"
+        ],
+        "numbers": "3|7|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 41,
+                        "prize": "$456"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 68,
+                        "prize": "$146"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 194,
+                        "prize": "$301"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 339,
+                        "prize": "$73"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16513",
+        "winnerCount": 642
+    },
+    {
+        "drawTime": "20200301130000",
+        "jackpot": [
+            "$611"
+        ],
+        "numbers": "2|7|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 31,
+                        "prize": "$611"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 111,
+                        "prize": "$96"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 127,
+                        "prize": "$354"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 811,
+                        "prize": "$48"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16512",
+        "winnerCount": 1080
+    },
+    {
+        "drawTime": "20200229183000",
+        "jackpot": [
+            "$577"
+        ],
+        "numbers": "7|8|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 28,
+                        "prize": "$577"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 103,
+                        "prize": "$92"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 168,
+                        "prize": "$335"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 875,
+                        "prize": "$46"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16511",
+        "winnerCount": 1174
+    },
+    {
+        "drawTime": "20200229130000",
+        "jackpot": [
+            "$605"
+        ],
+        "numbers": "6|7|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 31,
+                        "prize": "$605"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 115,
+                        "prize": "$96"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 140,
+                        "prize": "$351"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 867,
+                        "prize": "$48"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16510",
+        "winnerCount": 1153
+    },
+    {
+        "drawTime": "20200228183000",
+        "jackpot": [
+            "$492"
+        ],
+        "numbers": "3|0|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 58,
+                        "prize": "$492"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 91,
+                        "prize": "$78"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 209,
+                        "prize": "$285"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 784,
+                        "prize": "$39"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16509",
+        "winnerCount": 1142
+    },
+    {
+        "drawTime": "20200228130000",
+        "jackpot": [
+            "$402"
+        ],
+        "numbers": "1|3|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 48,
+                        "prize": "$402"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 248,
+                        "prize": "$64"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 148,
+                        "prize": "$233"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1552,
+                        "prize": "$32"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16508",
+        "winnerCount": 1996
+    },
+    {
+        "drawTime": "20200227183000",
+        "jackpot": [
+            "$650"
+        ],
+        "numbers": "7|5|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 47,
+                        "prize": "$650"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 92,
+                        "prize": "$104"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 98,
+                        "prize": "$377"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 715,
+                        "prize": "$52"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16507",
+        "winnerCount": 952
+    },
+    {
+        "drawTime": "20200227130000",
+        "jackpot": [
+            "$650"
+        ],
+        "numbers": "3|5|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 32,
+                        "prize": "$650"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 39,
+                        "prize": "$208"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 131,
+                        "prize": "$429"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 236,
+                        "prize": "$104"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16506",
+        "winnerCount": 438
+    },
+    {
+        "drawTime": "20200226183000",
+        "jackpot": [
+            "$485"
+        ],
+        "numbers": "0|1|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 50,
+                        "prize": "$485"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 41,
+                        "prize": "$154"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 173,
+                        "prize": "$320"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 306,
+                        "prize": "$77"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16505",
+        "winnerCount": 570
+    },
+    {
+        "drawTime": "20200226130000",
+        "jackpot": [
+            "$506"
+        ],
+        "numbers": "4|8|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 24,
+                        "prize": "$506"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 125,
+                        "prize": "$80"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 195,
+                        "prize": "$293"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 712,
+                        "prize": "$40"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16504",
+        "winnerCount": 1056
+    },
+    {
+        "drawTime": "20200225183000",
+        "jackpot": [
+            "$406"
+        ],
+        "numbers": "5|3|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 76,
+                        "prize": "$406"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 119,
+                        "prize": "$64"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 183,
+                        "prize": "$235"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 816,
+                        "prize": "$32"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16503",
+        "winnerCount": 1194
+    },
+    {
+        "drawTime": "20200225130000",
+        "jackpot": [
+            "$561"
+        ],
+        "numbers": "3|8|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 46,
+                        "prize": "$561"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 68,
+                        "prize": "$88"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 120,
+                        "prize": "$325"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 733,
+                        "prize": "$44"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16502",
+        "winnerCount": 967
+    },
+    {
+        "drawTime": "20200224183000",
+        "jackpot": [
+            "$380"
+        ],
+        "numbers": "3|4|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 73,
+                        "prize": "$380"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 57,
+                        "prize": "$120"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 209,
+                        "prize": "$251"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 358,
+                        "prize": "$60"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16501",
+        "winnerCount": 697
+    },
+    {
+        "drawTime": "20200224130000",
+        "jackpot": [
+            "$548"
+        ],
+        "numbers": "4|3|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 36,
+                        "prize": "$548"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 113,
+                        "prize": "$86"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 132,
+                        "prize": "$318"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 690,
+                        "prize": "$43"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16500",
+        "winnerCount": 971
+    },
+    {
+        "drawTime": "20200223183000",
+        "jackpot": [
+            "$585"
+        ],
+        "numbers": "9|0|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 26,
+                        "prize": "$585"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 76,
+                        "prize": "$92"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 132,
+                        "prize": "$339"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 766,
+                        "prize": "$46"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16499",
+        "winnerCount": 1000
+    },
+    {
+        "drawTime": "20200223130000",
+        "jackpot": [
+            "$515"
+        ],
+        "numbers": "7|3|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 31,
+                        "prize": "$515"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 45,
+                        "prize": "$164"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 185,
+                        "prize": "$340"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 242,
+                        "prize": "$82"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16498",
+        "winnerCount": 503
+    },
+    {
+        "drawTime": "20200222183000",
+        "jackpot": [
+            "$625"
+        ],
+        "numbers": "9|9|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 20,
+                        "prize": "$625"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 32,
+                        "prize": "$200"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 153,
+                        "prize": "$412"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 331,
+                        "prize": "$100"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16497",
+        "winnerCount": 536
+    },
+    {
+        "drawTime": "20200222130000",
+        "jackpot": [
+            "$688"
+        ],
+        "numbers": "7|9|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 28,
+                        "prize": "$688"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 70,
+                        "prize": "$110"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 117,
+                        "prize": "$399"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 732,
+                        "prize": "$55"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16496",
+        "winnerCount": 947
+    },
+    {
+        "drawTime": "20200221183000",
+        "jackpot": [
+            "$665"
+        ],
+        "numbers": "4|1|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 40,
+                        "prize": "$665"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 60,
+                        "prize": "$106"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 142,
+                        "prize": "$386"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 603,
+                        "prize": "$53"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16495",
+        "winnerCount": 845
+    },
+    {
+        "drawTime": "20200221130000",
+        "jackpot": [
+            "$478"
+        ],
+        "numbers": "4|6|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 47,
+                        "prize": "$478"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 135,
+                        "prize": "$76"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 179,
+                        "prize": "$277"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 800,
+                        "prize": "$38"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16494",
+        "winnerCount": 1161
+    },
+    {
+        "drawTime": "20200220183000",
+        "jackpot": [
+            "$324"
+        ],
+        "numbers": "9|6|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 57,
+                        "prize": "$324"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 167,
+                        "prize": "$50"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 251,
+                        "prize": "$188"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1434,
+                        "prize": "$25"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16493",
+        "winnerCount": 1909
+    },
+    {
+        "drawTime": "20200220130000",
+        "jackpot": [
+            "$332"
+        ],
+        "numbers": "3|9|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 92,
+                        "prize": "$332"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 166,
+                        "prize": "$52"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 182,
+                        "prize": "$192"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 1322,
+                        "prize": "$26"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16492",
+        "winnerCount": 1762
+    },
+    {
+        "drawTime": "20200219183000",
+        "jackpot": [
+            "$554"
+        ],
+        "numbers": "3|4|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 32,
+                        "prize": "$554"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 44,
+                        "prize": "$176"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 160,
+                        "prize": "$365"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 269,
+                        "prize": "$88"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16491",
+        "winnerCount": 505
+    },
+    {
+        "drawTime": "20200219130000",
+        "jackpot": [
+            "$807"
+        ],
+        "numbers": "8|6|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 16,
+                        "prize": "$807"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 31,
+                        "prize": "$258"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 114,
+                        "prize": "$532"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 183,
+                        "prize": "$129"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16490",
+        "winnerCount": 344
+    },
+    {
+        "drawTime": "20200218183000",
+        "jackpot": [
+            "$359"
+        ],
+        "numbers": "2|4|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 106,
+                        "prize": "$359"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 112,
+                        "prize": "$56"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 198,
+                        "prize": "$208"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 710,
+                        "prize": "$28"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16489",
+        "winnerCount": 1126
+    },
+    {
+        "drawTime": "20200218130000",
+        "jackpot": [
+            "$685"
+        ],
+        "numbers": "2|9|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 31,
+                        "prize": "$685"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 90,
+                        "prize": "$108"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 79,
+                        "prize": "$397"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 699,
+                        "prize": "$54"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16488",
+        "winnerCount": 899
+    },
+    {
+        "drawTime": "20200217183000",
+        "jackpot": [
+            "$469"
+        ],
+        "numbers": "3|2|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 32,
+                        "prize": "$469"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 122,
+                        "prize": "$74"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 193,
+                        "prize": "$272"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 685,
+                        "prize": "$37"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16487",
+        "winnerCount": 1032
+    },
+    {
+        "drawTime": "20200217130000",
+        "jackpot": [
+            "$554"
+        ],
+        "numbers": "2|7|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 44,
+                        "prize": "$554"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 102,
+                        "prize": "$88"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 113,
+                        "prize": "$321"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 662,
+                        "prize": "$44"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16486",
+        "winnerCount": 921
+    },
+    {
+        "drawTime": "20200216183000",
+        "jackpot": [
+            "$655"
+        ],
+        "numbers": "0|0|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 28,
+                        "prize": "$655"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 33,
+                        "prize": "$208"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 107,
+                        "prize": "$432"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 302,
+                        "prize": "$104"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16485",
+        "winnerCount": 470
+    },
+    {
+        "drawTime": "20200216130000",
+        "jackpot": [
+            "$531"
+        ],
+        "numbers": "6|8|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 44,
+                        "prize": "$531"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 77,
+                        "prize": "$84"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 148,
+                        "prize": "$308"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 701,
+                        "prize": "$42"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16484",
+        "winnerCount": 970
+    },
+    {
+        "drawTime": "20200215183000",
+        "jackpot": [
+            "$632"
+        ],
+        "numbers": "7|6|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 33,
+                        "prize": "$632"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 101,
+                        "prize": "$100"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 128,
+                        "prize": "$367"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 730,
+                        "prize": "$50"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16483",
+        "winnerCount": 992
+    },
+    {
+        "drawTime": "20200215130000",
+        "jackpot": [
+            "$655"
+        ],
+        "numbers": "4|3|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 18,
+                        "prize": "$655"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 89,
+                        "prize": "$104"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 122,
+                        "prize": "$380"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 825,
+                        "prize": "$52"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16482",
+        "winnerCount": 1054
+    },
+    {
+        "drawTime": "20200214183000",
+        "jackpot": [
+            "$617"
+        ],
+        "numbers": "3|3|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 22,
+                        "prize": "$617"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 68,
+                        "prize": "$196"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 127,
+                        "prize": "$407"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 398,
+                        "prize": "$98"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16481",
+        "winnerCount": 615
+    },
+    {
+        "drawTime": "20200214130000",
+        "jackpot": [
+            "$703"
+        ],
+        "numbers": "0|9|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 27,
+                        "prize": "$703"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 91,
+                        "prize": "$112"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 120,
+                        "prize": "$407"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 639,
+                        "prize": "$56"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16480",
+        "winnerCount": 877
+    },
+    {
+        "drawTime": "20200213183000",
+        "jackpot": [
+            "$497"
+        ],
+        "numbers": "0|6|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 45,
+                        "prize": "$497"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 100,
+                        "prize": "$78"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 155,
+                        "prize": "$288"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 920,
+                        "prize": "$39"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16479",
+        "winnerCount": 1220
+    },
+    {
+        "drawTime": "20200213130000",
+        "jackpot": [
+            "$705"
+        ],
+        "numbers": "0|2|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 24,
+                        "prize": "$705"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 42,
+                        "prize": "$112"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 131,
+                        "prize": "$409"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 597,
+                        "prize": "$56"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16478",
+        "winnerCount": 794
+    },
+    {
+        "drawTime": "20200212183000",
+        "jackpot": [
+            "$473"
+        ],
+        "numbers": "3|8|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 36,
+                        "prize": "$473"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 129,
+                        "prize": "$74"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 181,
+                        "prize": "$274"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 905,
+                        "prize": "$37"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16477",
+        "winnerCount": 1251
+    },
+    {
+        "drawTime": "20200212130000",
+        "jackpot": [
+            "$656"
+        ],
+        "numbers": "1|8|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 37,
+                        "prize": "$656"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 98,
+                        "prize": "$104"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 82,
+                        "prize": "$380"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 764,
+                        "prize": "$52"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16476",
+        "winnerCount": 981
+    },
+    {
+        "drawTime": "20200211183000",
+        "jackpot": [
+            "$232"
+        ],
+        "numbers": "1|0|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 129,
+                        "prize": "$232"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 80,
+                        "prize": "$74"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 376,
+                        "prize": "$153"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 426,
+                        "prize": "$37"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16475",
+        "winnerCount": 1011
+    },
+    {
+        "drawTime": "20200211130000",
+        "jackpot": [
+            "$384"
+        ],
+        "numbers": "1|3|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 93,
+                        "prize": "$384"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 81,
+                        "prize": "$60"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 164,
+                        "prize": "$222"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 902,
+                        "prize": "$30"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16474",
+        "winnerCount": 1240
+    },
+    {
+        "drawTime": "20200210183000",
+        "jackpot": [
+            "$533"
+        ],
+        "numbers": "0|9|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 50,
+                        "prize": "$533"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 89,
+                        "prize": "$84"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 136,
+                        "prize": "$309"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 772,
+                        "prize": "$42"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16473",
+        "winnerCount": 1047
+    },
+    {
+        "drawTime": "20200210130000",
+        "jackpot": [
+            "$452"
+        ],
+        "numbers": "6|9|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 48,
+                        "prize": "$452"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 96,
+                        "prize": "$72"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 171,
+                        "prize": "$262"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 801,
+                        "prize": "$36"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16472",
+        "winnerCount": 1116
+    },
+    {
+        "drawTime": "20200209183000",
+        "jackpot": [
+            "$828"
+        ],
+        "numbers": "6|4|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 13,
+                        "prize": "$828"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 24,
+                        "prize": "$264"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 101,
+                        "prize": "$547"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 217,
+                        "prize": "$132"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16471",
+        "winnerCount": 355
+    },
+    {
+        "drawTime": "20200209130000",
+        "jackpot": [
+            "$434"
+        ],
+        "numbers": "9|5|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 43,
+                        "prize": "$434"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 55,
+                        "prize": "$138"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 175,
+                        "prize": "$286"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 407,
+                        "prize": "$69"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16470",
+        "winnerCount": 680
+    },
+    {
+        "drawTime": "20200208183000",
+        "jackpot": [
+            "$559"
+        ],
+        "numbers": "9|2|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 36,
+                        "prize": "$559"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 50,
+                        "prize": "$178"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 161,
+                        "prize": "$369"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 332,
+                        "prize": "$89"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16469",
+        "winnerCount": 579
+    },
+    {
+        "drawTime": "20200208130000",
+        "jackpot": [
+            "$581"
+        ],
+        "numbers": "2|5|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 47,
+                        "prize": "$581"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 128,
+                        "prize": "$92"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 127,
+                        "prize": "$337"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 746,
+                        "prize": "$46"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16468",
+        "winnerCount": 1048
+    },
+    {
+        "drawTime": "20200207183000",
+        "jackpot": [
+            "$347"
+        ],
+        "numbers": "0|2|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 118,
+                        "prize": "$347"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 106,
+                        "prize": "$54"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 263,
+                        "prize": "$201"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 860,
+                        "prize": "$27"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 3",
+        "lotteryID": "us_ca-daily-3",
+        "issue": "16467",
+        "winnerCount": 1347
+    }
+]

--- a/crawler/us/ca/history/us_ca-daily-4.json
+++ b/crawler/us/ca/history/us_ca-daily-4.json
@@ -1,0 +1,7100 @@
+[
+    {
+        "drawTime": "20200805183000",
+        "jackpot": [
+            "$5,404"
+        ],
+        "numbers": "3|7|0|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$5,404"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 26,
+                        "prize": "$216"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$2,810"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 172,
+                        "prize": "$108"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4462",
+        "winnerCount": 205
+    },
+    {
+        "drawTime": "20200804183000",
+        "jackpot": [
+            "$5,413"
+        ],
+        "numbers": "6|1|0|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$5,413"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 38,
+                        "prize": "$216"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$2,814"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 146,
+                        "prize": "$108"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4461",
+        "winnerCount": 191
+    },
+    {
+        "drawTime": "20200803183000",
+        "jackpot": [
+            "$5,719"
+        ],
+        "numbers": "5|5|3|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$5,719"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 18,
+                        "prize": "$456"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$3,088"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 64,
+                        "prize": "$228"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4460",
+        "winnerCount": 89
+    },
+    {
+        "drawTime": "20200802183000",
+        "jackpot": [
+            "$13,475"
+        ],
+        "numbers": "8|3|0|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$13,475"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 6,
+                        "prize": "$1,078"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$7,276"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 34,
+                        "prize": "$539"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4459",
+        "winnerCount": 43
+    },
+    {
+        "drawTime": "20200801183000",
+        "jackpot": [
+            "$8,198"
+        ],
+        "numbers": "2|8|4|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$8,198"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 17,
+                        "prize": "$654"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 1,
+                        "prize": "$4,427"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 84,
+                        "prize": "$327"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4458",
+        "winnerCount": 103
+    },
+    {
+        "drawTime": "20200731183000",
+        "jackpot": [
+            "$4,700"
+        ],
+        "numbers": "6|5|5|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$4,700"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 25,
+                        "prize": "$376"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 12,
+                        "prize": "$2,541"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 59,
+                        "prize": "$188"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4457",
+        "winnerCount": 96
+    },
+    {
+        "drawTime": "20200730183000",
+        "jackpot": [
+            "$4,532"
+        ],
+        "numbers": "6|7|3|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$4,532"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 49,
+                        "prize": "$180"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 8,
+                        "prize": "$2,356"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 165,
+                        "prize": "$90"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4456",
+        "winnerCount": 223
+    },
+    {
+        "drawTime": "20200729183000",
+        "jackpot": [
+            "$4,930"
+        ],
+        "numbers": "0|8|9|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$4,930"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 20,
+                        "prize": "$394"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 9,
+                        "prize": "$2,662"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 57,
+                        "prize": "$197"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4455",
+        "winnerCount": 87
+    },
+    {
+        "drawTime": "20200728183000",
+        "jackpot": [
+            "$8,900"
+        ],
+        "numbers": "4|6|3|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$8,900"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 23,
+                        "prize": "$712"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 2,
+                        "prize": "$4,815"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 60,
+                        "prize": "$356"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4454",
+        "winnerCount": 85
+    },
+    {
+        "drawTime": "20200727183000",
+        "jackpot": [
+            "$7,120"
+        ],
+        "numbers": "4|3|7|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$7,120"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 8,
+                        "prize": "$568"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$3,845"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 40,
+                        "prize": "$284"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4453",
+        "winnerCount": 55
+    },
+    {
+        "drawTime": "20200726183000",
+        "jackpot": [
+            "$4,249"
+        ],
+        "numbers": "6|2|3|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$4,249"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 26,
+                        "prize": "$168"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 8,
+                        "prize": "$2,209"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 124,
+                        "prize": "$84"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4452",
+        "winnerCount": 161
+    },
+    {
+        "drawTime": "20200725183000",
+        "jackpot": [
+            "$5,106"
+        ],
+        "numbers": "0|9|9|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$5,106"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 5,
+                        "prize": "$1,224"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$3,166"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 19,
+                        "prize": "$612"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4451",
+        "winnerCount": 33
+    },
+    {
+        "drawTime": "20200724183000",
+        "jackpot": [
+            "$6,775"
+        ],
+        "numbers": "5|9|9|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$6,775"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 12,
+                        "prize": "$542"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 8,
+                        "prize": "$3,664"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 53,
+                        "prize": "$271"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4450",
+        "winnerCount": 73
+    },
+    {
+        "drawTime": "20200723183000",
+        "jackpot": [
+            "$7,024"
+        ],
+        "numbers": "5|7|9|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$7,024"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 45,
+                        "prize": "$280"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 2,
+                        "prize": "$3,652"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 152,
+                        "prize": "$140"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4449",
+        "winnerCount": 200
+    },
+    {
+        "drawTime": "20200722183000",
+        "jackpot": [
+            "$7,263"
+        ],
+        "numbers": "7|6|8|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$7,263"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 13,
+                        "prize": "$290"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$3,776"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 99,
+                        "prize": "$145"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4448",
+        "winnerCount": 118
+    },
+    {
+        "drawTime": "20200721183000",
+        "jackpot": [
+            "$4,377"
+        ],
+        "numbers": "1|8|0|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$4,377"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 53,
+                        "prize": "$174"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$2,276"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 153,
+                        "prize": "$87"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4447",
+        "winnerCount": 214
+    },
+    {
+        "drawTime": "20200720183000",
+        "jackpot": [
+            "$5,575"
+        ],
+        "numbers": "0|2|6|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$5,575"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 15,
+                        "prize": "$446"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$3,010"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 79,
+                        "prize": "$223"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4446",
+        "winnerCount": 101
+    },
+    {
+        "drawTime": "20200719183000",
+        "jackpot": [
+            "$4,730"
+        ],
+        "numbers": "2|7|0|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$4,730"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 13,
+                        "prize": "$378"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$2,554"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 81,
+                        "prize": "$189"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4445",
+        "winnerCount": 102
+    },
+    {
+        "drawTime": "20200718183000",
+        "jackpot": [
+            "$5,769"
+        ],
+        "numbers": "9|0|3|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$5,769"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 28,
+                        "prize": "$230"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$3,000"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 142,
+                        "prize": "$115"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4444",
+        "winnerCount": 177
+    },
+    {
+        "drawTime": "20200717183000",
+        "jackpot": [
+            "$6,400"
+        ],
+        "numbers": "6|3|1|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$6,400"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 29,
+                        "prize": "$256"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$3,348"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 144,
+                        "prize": "$128"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4443",
+        "winnerCount": 180
+    },
+    {
+        "drawTime": "20200716183000",
+        "jackpot": [
+            "$6,792"
+        ],
+        "numbers": "9|5|3|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$6,792"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 40,
+                        "prize": "$270"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$3,532"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 115,
+                        "prize": "$135"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4442",
+        "winnerCount": 160
+    },
+    {
+        "drawTime": "20200715183000",
+        "jackpot": [
+            "$5,020"
+        ],
+        "numbers": "1|8|6|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$5,020"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 36,
+                        "prize": "$200"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$2,610"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 137,
+                        "prize": "$100"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4441",
+        "winnerCount": 181
+    },
+    {
+        "drawTime": "20200714183000",
+        "jackpot": [
+            "$4,982"
+        ],
+        "numbers": "7|3|4|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$4,982"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 11,
+                        "prize": "$398"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$2,690"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 67,
+                        "prize": "$199"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4440",
+        "winnerCount": 87
+    },
+    {
+        "drawTime": "20200713183000",
+        "jackpot": [
+            "$1,960"
+        ],
+        "numbers": "1|2|1|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 6,
+                        "prize": "$1,960"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 27,
+                        "prize": "$156"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 21,
+                        "prize": "$1,058"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 93,
+                        "prize": "$78"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4439",
+        "winnerCount": 147
+    },
+    {
+        "drawTime": "20200712183000",
+        "jackpot": [
+            "$5,941"
+        ],
+        "numbers": "6|6|8|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$5,941"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 11,
+                        "prize": "$474"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$3,208"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 43,
+                        "prize": "$237"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4438",
+        "winnerCount": 61
+    },
+    {
+        "drawTime": "20200711183000",
+        "jackpot": [
+            "$3,646"
+        ],
+        "numbers": "6|2|1|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 4,
+                        "prize": "$3,646"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 52,
+                        "prize": "$144"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$1,896"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 198,
+                        "prize": "$72"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4437",
+        "winnerCount": 261
+    },
+    {
+        "drawTime": "20200710183000",
+        "jackpot": [
+            "$4,400"
+        ],
+        "numbers": "7|1|9|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$4,400"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 19,
+                        "prize": "$352"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 11,
+                        "prize": "$2,380"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 98,
+                        "prize": "$176"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4436",
+        "winnerCount": 128
+    },
+    {
+        "drawTime": "20200709183000",
+        "jackpot": [
+            "$1,548"
+        ],
+        "numbers": "7|7|7|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 8,
+                        "prize": "$1,548"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 18,
+                        "prize": "$370"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 22,
+                        "prize": "$960"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 41,
+                        "prize": "$185"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4435",
+        "winnerCount": 89
+    },
+    {
+        "drawTime": "20200708183000",
+        "jackpot": [
+            "$3,086"
+        ],
+        "numbers": "1|1|1|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 4,
+                        "prize": "$3,086"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 3,
+                        "prize": "$740"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 13,
+                        "prize": "$1,913"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 24,
+                        "prize": "$370"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4434",
+        "winnerCount": 44
+    },
+    {
+        "drawTime": "20200707183000",
+        "jackpot": [
+            "$4,519"
+        ],
+        "numbers": "0|8|5|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$4,519"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 43,
+                        "prize": "$180"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 9,
+                        "prize": "$2,350"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 154,
+                        "prize": "$90"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4433",
+        "winnerCount": 207
+    },
+    {
+        "drawTime": "20200706183000",
+        "jackpot": [
+            "$4,984"
+        ],
+        "numbers": "0|4|1|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$4,984"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 14,
+                        "prize": "$198"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 8,
+                        "prize": "$2,591"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 125,
+                        "prize": "$99"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4432",
+        "winnerCount": 149
+    },
+    {
+        "drawTime": "20200705183000",
+        "jackpot": [
+            "$3,710"
+        ],
+        "numbers": "4|7|7|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 5,
+                        "prize": "$3,710"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 3,
+                        "prize": "$890"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$2,300"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 17,
+                        "prize": "$445"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4431",
+        "winnerCount": 32
+    },
+    {
+        "drawTime": "20200704183000",
+        "jackpot": [
+            "$7,625"
+        ],
+        "numbers": "7|7|6|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$7,625"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 9,
+                        "prize": "$610"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$4,127"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 49,
+                        "prize": "$305"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4430",
+        "winnerCount": 65
+    },
+    {
+        "drawTime": "20200703183000",
+        "jackpot": [
+            "$4,158"
+        ],
+        "numbers": "1|4|7|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$4,158"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 32,
+                        "prize": "$166"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 12,
+                        "prize": "$2,162"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 150,
+                        "prize": "$83"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4429",
+        "winnerCount": 196
+    },
+    {
+        "drawTime": "20200702183000",
+        "jackpot": [
+            "$3,817"
+        ],
+        "numbers": "3|0|9|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$3,817"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 82,
+                        "prize": "$152"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$1,985"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 190,
+                        "prize": "$76"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4428",
+        "winnerCount": 281
+    },
+    {
+        "drawTime": "20200701183000",
+        "jackpot": [
+            "$5,790"
+        ],
+        "numbers": "9|1|0|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$5,790"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 37,
+                        "prize": "$230"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$3,011"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 201,
+                        "prize": "$115"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4427",
+        "winnerCount": 243
+    },
+    {
+        "drawTime": "20200630183000",
+        "jackpot": [
+            "$6,603"
+        ],
+        "numbers": "7|4|4|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$6,603"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 14,
+                        "prize": "$528"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$3,566"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 61,
+                        "prize": "$264"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4426",
+        "winnerCount": 80
+    },
+    {
+        "drawTime": "20200629183000",
+        "jackpot": [
+            "$3,749"
+        ],
+        "numbers": "2|6|8|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 4,
+                        "prize": "$3,749"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 46,
+                        "prize": "$148"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$1,949"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 135,
+                        "prize": "$74"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4425",
+        "winnerCount": 192
+    },
+    {
+        "drawTime": "20200628183000",
+        "jackpot": [
+            "$4,565"
+        ],
+        "numbers": "4|1|8|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$4,565"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 38,
+                        "prize": "$182"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 8,
+                        "prize": "$2,374"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 165,
+                        "prize": "$91"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4424",
+        "winnerCount": 212
+    },
+    {
+        "drawTime": "20200627183000",
+        "jackpot": [
+            "$5,735"
+        ],
+        "numbers": "0|3|4|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$5,735"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 35,
+                        "prize": "$228"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$2,982"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 177,
+                        "prize": "$114"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4423",
+        "winnerCount": 217
+    },
+    {
+        "drawTime": "20200626183000",
+        "jackpot": [
+            "$4,536"
+        ],
+        "numbers": "5|7|4|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$4,536"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 30,
+                        "prize": "$180"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 8,
+                        "prize": "$2,359"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 125,
+                        "prize": "$90"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4422",
+        "winnerCount": 166
+    },
+    {
+        "drawTime": "20200625183000",
+        "jackpot": [
+            "$3,678"
+        ],
+        "numbers": "1|1|4|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$3,678"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 34,
+                        "prize": "$294"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$1,986"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 94,
+                        "prize": "$147"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4421",
+        "winnerCount": 138
+    },
+    {
+        "drawTime": "20200624183000",
+        "jackpot": [
+            "$4,098"
+        ],
+        "numbers": "3|8|4|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 5,
+                        "prize": "$4,098"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 31,
+                        "prize": "$162"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$2,131"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 116,
+                        "prize": "$81"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4420",
+        "winnerCount": 158
+    },
+    {
+        "drawTime": "20200623183000",
+        "jackpot": [
+            "$4,229"
+        ],
+        "numbers": "0|5|2|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$4,229"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 35,
+                        "prize": "$338"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 10,
+                        "prize": "$2,283"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 52,
+                        "prize": "$169"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4419",
+        "winnerCount": 98
+    },
+    {
+        "drawTime": "20200622183000",
+        "jackpot": [
+            "$7,510"
+        ],
+        "numbers": "3|7|2|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$7,510"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 34,
+                        "prize": "$300"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 2,
+                        "prize": "$3,905"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 135,
+                        "prize": "$150"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4418",
+        "winnerCount": 172
+    },
+    {
+        "drawTime": "20200621183000",
+        "jackpot": [
+            "$8,459"
+        ],
+        "numbers": "8|8|0|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$8,459"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 9,
+                        "prize": "$676"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$4,568"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 49,
+                        "prize": "$338"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4417",
+        "winnerCount": 62
+    },
+    {
+        "drawTime": "20200620183000",
+        "jackpot": [
+            "$5,675"
+        ],
+        "numbers": "1|7|1|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$5,675"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 23,
+                        "prize": "$454"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$3,066"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 103,
+                        "prize": "$227"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4416",
+        "winnerCount": 131
+    },
+    {
+        "drawTime": "20200619183000",
+        "jackpot": [
+            "$8,175"
+        ],
+        "numbers": "2|6|4|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$8,175"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 18,
+                        "prize": "$654"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$4,427"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 62,
+                        "prize": "$327"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4415",
+        "winnerCount": 84
+    },
+    {
+        "drawTime": "20200618183000",
+        "jackpot": [
+            "$5,900"
+        ],
+        "numbers": "5|1|7|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$5,900"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 51,
+                        "prize": "$236"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$3,081"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 188,
+                        "prize": "$118"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4414",
+        "winnerCount": 243
+    },
+    {
+        "drawTime": "20200617183000",
+        "jackpot": [
+            "$5,424"
+        ],
+        "numbers": "3|5|7|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$5,424"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 18,
+                        "prize": "$432"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$2,929"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 65,
+                        "prize": "$216"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4413",
+        "winnerCount": 90
+    },
+    {
+        "drawTime": "20200616183000",
+        "jackpot": [
+            "$4,575"
+        ],
+        "numbers": "8|1|2|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$4,575"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 23,
+                        "prize": "$366"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 9,
+                        "prize": "$2,478"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 90,
+                        "prize": "$183"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4412",
+        "winnerCount": 122
+    },
+    {
+        "drawTime": "20200615183000",
+        "jackpot": [
+            "$3,802"
+        ],
+        "numbers": "3|7|0|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$3,802"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 39,
+                        "prize": "$152"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 10,
+                        "prize": "$1,977"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 168,
+                        "prize": "$76"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4411",
+        "winnerCount": 219
+    },
+    {
+        "drawTime": "20200614183000",
+        "jackpot": [
+            "$7,227"
+        ],
+        "numbers": "9|8|5|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$7,227"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 28,
+                        "prize": "$288"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$3,758"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 126,
+                        "prize": "$144"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4410",
+        "winnerCount": 158
+    },
+    {
+        "drawTime": "20200613183000",
+        "jackpot": [
+            "$4,470"
+        ],
+        "numbers": "1|5|6|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$4,470"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 23,
+                        "prize": "$178"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$2,324"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 173,
+                        "prize": "$89"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4409",
+        "winnerCount": 206
+    },
+    {
+        "drawTime": "20200612183000",
+        "jackpot": [
+            "$4,876"
+        ],
+        "numbers": "8|0|5|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$4,876"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 39,
+                        "prize": "$194"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$2,535"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 129,
+                        "prize": "$97"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4408",
+        "winnerCount": 177
+    },
+    {
+        "drawTime": "20200611183000",
+        "jackpot": [
+            "$8,475"
+        ],
+        "numbers": "0|9|2|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$8,475"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 9,
+                        "prize": "$678"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$4,578"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 41,
+                        "prize": "$339"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4407",
+        "winnerCount": 56
+    },
+    {
+        "drawTime": "20200610183000",
+        "jackpot": [
+            "$4,101"
+        ],
+        "numbers": "3|6|1|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$4,101"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 22,
+                        "prize": "$164"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 9,
+                        "prize": "$2,132"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 149,
+                        "prize": "$82"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4406",
+        "winnerCount": 183
+    },
+    {
+        "drawTime": "20200609183000",
+        "jackpot": [
+            "$4,135"
+        ],
+        "numbers": "0|0|6|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$4,135"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 20,
+                        "prize": "$330"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 11,
+                        "prize": "$2,232"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 53,
+                        "prize": "$165"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4405",
+        "winnerCount": 86
+    },
+    {
+        "drawTime": "20200608183000",
+        "jackpot": [
+            "$4,118"
+        ],
+        "numbers": "7|3|5|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$4,118"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 42,
+                        "prize": "$164"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 8,
+                        "prize": "$2,141"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 165,
+                        "prize": "$82"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4404",
+        "winnerCount": 217
+    },
+    {
+        "drawTime": "20200607183000",
+        "jackpot": [
+            "$6,150"
+        ],
+        "numbers": "3|8|1|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$6,150"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 26,
+                        "prize": "$246"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$3,210"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 157,
+                        "prize": "$123"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4403",
+        "winnerCount": 189
+    },
+    {
+        "drawTime": "20200606183000",
+        "jackpot": [
+            "$5,476"
+        ],
+        "numbers": "1|4|9|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$5,476"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 23,
+                        "prize": "$438"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$2,957"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 115,
+                        "prize": "$219"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4402",
+        "winnerCount": 142
+    },
+    {
+        "drawTime": "20200605183000",
+        "jackpot": [
+            "$4,499"
+        ],
+        "numbers": "3|0|0|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$4,499"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 22,
+                        "prize": "$358"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$2,429"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 84,
+                        "prize": "$179"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4401",
+        "winnerCount": 115
+    },
+    {
+        "drawTime": "20200604183000",
+        "jackpot": [
+            "$10,876"
+        ],
+        "numbers": "7|3|3|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$10,876"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 19,
+                        "prize": "$870"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 0,
+                        "prize": "$5,872"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 48,
+                        "prize": "$435"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4400",
+        "winnerCount": 68
+    },
+    {
+        "drawTime": "20200603183000",
+        "jackpot": [
+            "$4,736"
+        ],
+        "numbers": "3|7|5|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$4,736"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 42,
+                        "prize": "$188"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$2,462"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 187,
+                        "prize": "$94"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4399",
+        "winnerCount": 237
+    },
+    {
+        "drawTime": "20200602183000",
+        "jackpot": [
+            "$5,390"
+        ],
+        "numbers": "3|8|1|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$5,390"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 25,
+                        "prize": "$214"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$2,803"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 145,
+                        "prize": "$107"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4398",
+        "winnerCount": 178
+    },
+    {
+        "drawTime": "20200601183000",
+        "jackpot": [
+            "$4,453"
+        ],
+        "numbers": "6|2|3|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$4,453"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 20,
+                        "prize": "$178"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 9,
+                        "prize": "$2,315"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 132,
+                        "prize": "$89"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4397",
+        "winnerCount": 163
+    },
+    {
+        "drawTime": "20200531183000",
+        "jackpot": [
+            "$4,292"
+        ],
+        "numbers": "1|4|8|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$4,292"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 32,
+                        "prize": "$170"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$2,232"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 122,
+                        "prize": "$85"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4396",
+        "winnerCount": 164
+    },
+    {
+        "drawTime": "20200530183000",
+        "jackpot": [
+            "$5,315"
+        ],
+        "numbers": "9|4|9|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$5,315"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 28,
+                        "prize": "$424"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$2,870"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 110,
+                        "prize": "$212"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4395",
+        "winnerCount": 142
+    },
+    {
+        "drawTime": "20200529183000",
+        "jackpot": [
+            "$3,240"
+        ],
+        "numbers": "1|7|0|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 6,
+                        "prize": "$3,240"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 46,
+                        "prize": "$128"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$1,685"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 202,
+                        "prize": "$64"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4394",
+        "winnerCount": 261
+    },
+    {
+        "drawTime": "20200528183000",
+        "jackpot": [
+            "$6,050"
+        ],
+        "numbers": "2|8|0|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$6,050"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 32,
+                        "prize": "$242"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$3,162"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 159,
+                        "prize": "$121"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4393",
+        "winnerCount": 197
+    },
+    {
+        "drawTime": "20200527183000",
+        "jackpot": [
+            "$2,980"
+        ],
+        "numbers": "2|1|4|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$2,980"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 70,
+                        "prize": "$118"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 10,
+                        "prize": "$1,550"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 260,
+                        "prize": "$59"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4392",
+        "winnerCount": 342
+    },
+    {
+        "drawTime": "20200526183000",
+        "jackpot": [
+            "$6,130"
+        ],
+        "numbers": "1|7|5|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$6,130"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 15,
+                        "prize": "$490"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$3,310"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 73,
+                        "prize": "$245"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4391",
+        "winnerCount": 93
+    },
+    {
+        "drawTime": "20200525183000",
+        "jackpot": [
+            "$7,770"
+        ],
+        "numbers": "6|1|8|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$7,770"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 28,
+                        "prize": "$310"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 2,
+                        "prize": "$4,040"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 121,
+                        "prize": "$155"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4390",
+        "winnerCount": 152
+    },
+    {
+        "drawTime": "20200524183000",
+        "jackpot": [
+            "$11,825"
+        ],
+        "numbers": "9|9|8|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$11,825"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 10,
+                        "prize": "$946"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 2,
+                        "prize": "$6,387"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 46,
+                        "prize": "$473"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4389",
+        "winnerCount": 58
+    },
+    {
+        "drawTime": "20200523183000",
+        "jackpot": [
+            "$7,900"
+        ],
+        "numbers": "7|0|4|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$7,900"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 32,
+                        "prize": "$316"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$4,117"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 134,
+                        "prize": "$158"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4388",
+        "winnerCount": 170
+    },
+    {
+        "drawTime": "20200522183000",
+        "jackpot": [
+            "$3,649"
+        ],
+        "numbers": "2|8|0|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 4,
+                        "prize": "$3,649"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 23,
+                        "prize": "$144"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 10,
+                        "prize": "$1,897"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 161,
+                        "prize": "$72"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4387",
+        "winnerCount": 198
+    },
+    {
+        "drawTime": "20200521183000",
+        "jackpot": [
+            "$3,195"
+        ],
+        "numbers": "2|6|2|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 7,
+                        "prize": "$3,195"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 10,
+                        "prize": "$254"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 9,
+                        "prize": "$1,725"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 46,
+                        "prize": "$127"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4386",
+        "winnerCount": 72
+    },
+    {
+        "drawTime": "20200520183000",
+        "jackpot": [
+            "$9,175"
+        ],
+        "numbers": "3|1|2|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$9,175"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 10,
+                        "prize": "$734"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$4,966"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 65,
+                        "prize": "$367"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4385",
+        "winnerCount": 78
+    },
+    {
+        "drawTime": "20200519183000",
+        "jackpot": [
+            "$6,073"
+        ],
+        "numbers": "7|0|8|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$6,073"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 30,
+                        "prize": "$242"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$3,158"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 111,
+                        "prize": "$121"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4384",
+        "winnerCount": 148
+    },
+    {
+        "drawTime": "20200518183000",
+        "jackpot": [
+            "$3,253"
+        ],
+        "numbers": "3|0|0|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 9,
+                        "prize": "$3,253"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 16,
+                        "prize": "$260"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 0,
+                        "prize": "$1,756"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 80,
+                        "prize": "$130"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4383",
+        "winnerCount": 105
+    },
+    {
+        "drawTime": "20200517183000",
+        "jackpot": [
+            "$5,250"
+        ],
+        "numbers": "2|0|4|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$5,250"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 50,
+                        "prize": "$210"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 8,
+                        "prize": "$2,743"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 99,
+                        "prize": "$105"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4382",
+        "winnerCount": 157
+    },
+    {
+        "drawTime": "20200516183000",
+        "jackpot": [
+            "$3,674"
+        ],
+        "numbers": "9|1|7|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$3,674"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 28,
+                        "prize": "$292"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$1,984"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 134,
+                        "prize": "$146"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4381",
+        "winnerCount": 170
+    },
+    {
+        "drawTime": "20200515183000",
+        "jackpot": [
+            "$1,100"
+        ],
+        "numbers": "3|3|3|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 44,
+                        "prize": "$1,100"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 0,
+                        "prize": "Free play"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 0,
+                        "prize": "Free play"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 0,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4380",
+        "winnerCount": 44
+    },
+    {
+        "drawTime": "20200514183000",
+        "jackpot": [
+            "$6,680"
+        ],
+        "numbers": "2|1|8|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$6,680"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 10,
+                        "prize": "$534"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$3,607"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 58,
+                        "prize": "$267"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4379",
+        "winnerCount": 74
+    },
+    {
+        "drawTime": "20200513183000",
+        "jackpot": [
+            "$5,668"
+        ],
+        "numbers": "8|9|1|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$5,668"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 40,
+                        "prize": "$226"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 2,
+                        "prize": "$2,947"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 168,
+                        "prize": "$113"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4378",
+        "winnerCount": 212
+    },
+    {
+        "drawTime": "20200512183000",
+        "jackpot": [
+            "$6,853"
+        ],
+        "numbers": "5|8|1|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$6,853"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 11,
+                        "prize": "$548"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$3,700"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 49,
+                        "prize": "$274"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4377",
+        "winnerCount": 65
+    },
+    {
+        "drawTime": "20200511183000",
+        "jackpot": [
+            "$3,201"
+        ],
+        "numbers": "3|1|8|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$3,201"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 31,
+                        "prize": "$128"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 12,
+                        "prize": "$1,664"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 142,
+                        "prize": "$64"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4376",
+        "winnerCount": 188
+    },
+    {
+        "drawTime": "20200510183000",
+        "jackpot": [
+            "$4,485"
+        ],
+        "numbers": "3|3|1|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$4,485"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 13,
+                        "prize": "$358"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 10,
+                        "prize": "$2,422"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 47,
+                        "prize": "$179"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4375",
+        "winnerCount": 71
+    },
+    {
+        "drawTime": "20200509183000",
+        "jackpot": [
+            "$6,184"
+        ],
+        "numbers": "2|4|1|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$6,184"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 10,
+                        "prize": "$494"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$3,339"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 64,
+                        "prize": "$247"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4374",
+        "winnerCount": 80
+    },
+    {
+        "drawTime": "20200508183000",
+        "jackpot": [
+            "$4,425"
+        ],
+        "numbers": "5|1|0|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$4,425"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 26,
+                        "prize": "$354"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 8,
+                        "prize": "$2,398"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 102,
+                        "prize": "$177"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4373",
+        "winnerCount": 136
+    },
+    {
+        "drawTime": "20200507183000",
+        "jackpot": [
+            "$6,111"
+        ],
+        "numbers": "8|0|4|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$6,111"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 26,
+                        "prize": "$244"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$3,178"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 96,
+                        "prize": "$122"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4372",
+        "winnerCount": 129
+    },
+    {
+        "drawTime": "20200506183000",
+        "jackpot": [
+            "$6,041"
+        ],
+        "numbers": "6|0|3|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$6,041"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 20,
+                        "prize": "$240"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$3,141"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 93,
+                        "prize": "$120"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4371",
+        "winnerCount": 120
+    },
+    {
+        "drawTime": "20200505183000",
+        "jackpot": [
+            "$3,172"
+        ],
+        "numbers": "0|6|1|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$3,172"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 34,
+                        "prize": "$126"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 13,
+                        "prize": "$1,649"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 139,
+                        "prize": "$63"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4370",
+        "winnerCount": 189
+    },
+    {
+        "drawTime": "20200504183000",
+        "jackpot": [
+            "$7,388"
+        ],
+        "numbers": "8|6|3|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$7,388"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 6,
+                        "prize": "$590"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$3,989"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 44,
+                        "prize": "$295"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4369",
+        "winnerCount": 56
+    },
+    {
+        "drawTime": "20200503183000",
+        "jackpot": [
+            "$11,375"
+        ],
+        "numbers": "3|4|8|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$11,375"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 6,
+                        "prize": "$910"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$6,155"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 41,
+                        "prize": "$455"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4368",
+        "winnerCount": 50
+    },
+    {
+        "drawTime": "20200502183000",
+        "jackpot": [
+            "$5,393"
+        ],
+        "numbers": "6|0|2|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$5,393"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 22,
+                        "prize": "$214"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$2,804"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 112,
+                        "prize": "$107"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4367",
+        "winnerCount": 142
+    },
+    {
+        "drawTime": "20200501183000",
+        "jackpot": [
+            "$13,245"
+        ],
+        "numbers": "3|3|7|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$13,245"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 5,
+                        "prize": "$1,058"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 1,
+                        "prize": "$7,152"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 41,
+                        "prize": "$529"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4366",
+        "winnerCount": 48
+    },
+    {
+        "drawTime": "20200430183000",
+        "jackpot": [
+            "$5,061"
+        ],
+        "numbers": "2|4|7|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$5,061"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 22,
+                        "prize": "$404"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$2,733"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 65,
+                        "prize": "$202"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4365",
+        "winnerCount": 93
+    },
+    {
+        "drawTime": "20200429183000",
+        "jackpot": [
+            "$6,050"
+        ],
+        "numbers": "9|7|8|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$6,050"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 23,
+                        "prize": "$484"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$3,268"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 55,
+                        "prize": "$242"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4364",
+        "winnerCount": 83
+    },
+    {
+        "drawTime": "20200428183000",
+        "jackpot": [
+            "$4,613"
+        ],
+        "numbers": "5|8|6|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$4,613"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 18,
+                        "prize": "$184"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$2,399"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 111,
+                        "prize": "$92"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4363",
+        "winnerCount": 138
+    },
+    {
+        "drawTime": "20200427183000",
+        "jackpot": [
+            "$4,286"
+        ],
+        "numbers": "1|6|3|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$4,286"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 26,
+                        "prize": "$342"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$2,314"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 32,
+                        "prize": "$171"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4362",
+        "winnerCount": 66
+    },
+    {
+        "drawTime": "20200426183000",
+        "jackpot": [
+            "$4,778"
+        ],
+        "numbers": "8|1|7|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$4,778"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 8,
+                        "prize": "$382"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$2,580"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 51,
+                        "prize": "$191"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4361",
+        "winnerCount": 67
+    },
+    {
+        "drawTime": "20200425183000",
+        "jackpot": [
+            "$3,011"
+        ],
+        "numbers": "2|3|1|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 4,
+                        "prize": "$3,011"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 45,
+                        "prize": "$120"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 8,
+                        "prize": "$1,565"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 199,
+                        "prize": "$60"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4360",
+        "winnerCount": 256
+    },
+    {
+        "drawTime": "20200424183000",
+        "jackpot": [
+            "$11,650"
+        ],
+        "numbers": "7|6|3|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$11,650"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 11,
+                        "prize": "$932"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 2,
+                        "prize": "$6,300"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 41,
+                        "prize": "$466"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4359",
+        "winnerCount": 54
+    },
+    {
+        "drawTime": "20200423183000",
+        "jackpot": [
+            "$2,350"
+        ],
+        "numbers": "5|3|2|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 4,
+                        "prize": "$2,350"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 55,
+                        "prize": "$94"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 17,
+                        "prize": "$1,222"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 99,
+                        "prize": "$47"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4358",
+        "winnerCount": 175
+    },
+    {
+        "drawTime": "20200422183000",
+        "jackpot": [
+            "$5,754"
+        ],
+        "numbers": "8|7|4|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$5,754"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 19,
+                        "prize": "$230"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$2,992"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 83,
+                        "prize": "$115"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4357",
+        "winnerCount": 109
+    },
+    {
+        "drawTime": "20200421183000",
+        "jackpot": [
+            "$6,258"
+        ],
+        "numbers": "8|2|9|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$6,258"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 17,
+                        "prize": "$250"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$3,254"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 105,
+                        "prize": "$125"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4356",
+        "winnerCount": 127
+    },
+    {
+        "drawTime": "20200420183000",
+        "jackpot": [
+            "$4,269"
+        ],
+        "numbers": "6|4|2|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$4,269"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 34,
+                        "prize": "$170"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 9,
+                        "prize": "$2,220"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 106,
+                        "prize": "$85"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4355",
+        "winnerCount": 150
+    },
+    {
+        "drawTime": "20200419183000",
+        "jackpot": [
+            "$4,321"
+        ],
+        "numbers": "3|2|1|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$4,321"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 29,
+                        "prize": "$172"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 8,
+                        "prize": "$2,247"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 124,
+                        "prize": "$86"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4354",
+        "winnerCount": 162
+    },
+    {
+        "drawTime": "20200418183000",
+        "jackpot": [
+            "$2,801"
+        ],
+        "numbers": "2|0|2|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$2,801"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 28,
+                        "prize": "$224"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 15,
+                        "prize": "$1,512"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 74,
+                        "prize": "$112"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4353",
+        "winnerCount": 119
+    },
+    {
+        "drawTime": "20200417183000",
+        "jackpot": [
+            "$8,948"
+        ],
+        "numbers": "9|2|7|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$8,948"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 33,
+                        "prize": "$358"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 1,
+                        "prize": "$4,664"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 141,
+                        "prize": "$179"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4352",
+        "winnerCount": 175
+    },
+    {
+        "drawTime": "20200416183000",
+        "jackpot": [
+            "$4,770"
+        ],
+        "numbers": "4|4|7|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$4,770"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 22,
+                        "prize": "$380"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$2,576"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 49,
+                        "prize": "$190"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4351",
+        "winnerCount": 77
+    },
+    {
+        "drawTime": "20200415183000",
+        "jackpot": [
+            "$3,425"
+        ],
+        "numbers": "2|7|2|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$3,425"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 15,
+                        "prize": "$274"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 15,
+                        "prize": "$1,860"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 58,
+                        "prize": "$137"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4350",
+        "winnerCount": 88
+    },
+    {
+        "drawTime": "20200414183000",
+        "jackpot": [
+            "$5,716"
+        ],
+        "numbers": "7|0|2|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$5,716"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 18,
+                        "prize": "$228"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$2,972"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 89,
+                        "prize": "$114"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4349",
+        "winnerCount": 113
+    },
+    {
+        "drawTime": "20200413183000",
+        "jackpot": [
+            "$4,322"
+        ],
+        "numbers": "5|3|2|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$4,322"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 32,
+                        "prize": "$172"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$2,247"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 96,
+                        "prize": "$86"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4348",
+        "winnerCount": 136
+    },
+    {
+        "drawTime": "20200412183000",
+        "jackpot": [
+            "$5,567"
+        ],
+        "numbers": "5|1|5|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$5,567"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 8,
+                        "prize": "$444"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$3,006"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 44,
+                        "prize": "$222"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4347",
+        "winnerCount": 58
+    },
+    {
+        "drawTime": "20200411183000",
+        "jackpot": [
+            "$4,353"
+        ],
+        "numbers": "4|4|1|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$4,353"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 18,
+                        "prize": "$348"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$2,351"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 54,
+                        "prize": "$174"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4346",
+        "winnerCount": 80
+    },
+    {
+        "drawTime": "20200410183000",
+        "jackpot": [
+            "$3,962"
+        ],
+        "numbers": "9|1|5|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$3,962"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 42,
+                        "prize": "$158"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$2,060"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 165,
+                        "prize": "$79"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4345",
+        "winnerCount": 214
+    },
+    {
+        "drawTime": "20200409183000",
+        "jackpot": [
+            "$4,996"
+        ],
+        "numbers": "7|9|3|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$4,996"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 41,
+                        "prize": "$198"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 2,
+                        "prize": "$2,597"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 118,
+                        "prize": "$99"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4344",
+        "winnerCount": 163
+    },
+    {
+        "drawTime": "20200408183000",
+        "jackpot": [
+            "$6,229"
+        ],
+        "numbers": "4|1|9|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$6,229"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 23,
+                        "prize": "$248"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 2,
+                        "prize": "$3,239"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 141,
+                        "prize": "$124"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4343",
+        "winnerCount": 167
+    },
+    {
+        "drawTime": "20200407183000",
+        "jackpot": [
+            "$5,625"
+        ],
+        "numbers": "5|3|6|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$5,625"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 34,
+                        "prize": "$224"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 2,
+                        "prize": "$2,925"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 102,
+                        "prize": "$112"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4342",
+        "winnerCount": 140
+    },
+    {
+        "drawTime": "20200406183000",
+        "jackpot": [
+            "$6,305"
+        ],
+        "numbers": "7|6|1|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$6,305"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 6,
+                        "prize": "$504"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$3,405"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 36,
+                        "prize": "$252"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4341",
+        "winnerCount": 48
+    },
+    {
+        "drawTime": "20200405183000",
+        "jackpot": [
+            "$5,550"
+        ],
+        "numbers": "6|5|1|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$5,550"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 35,
+                        "prize": "$222"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$2,900"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 116,
+                        "prize": "$111"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4340",
+        "winnerCount": 156
+    },
+    {
+        "drawTime": "20200404183000",
+        "jackpot": [
+            "$5,725"
+        ],
+        "numbers": "5|4|6|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$5,725"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 8,
+                        "prize": "$458"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 8,
+                        "prize": "$3,091"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 46,
+                        "prize": "$229"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4339",
+        "winnerCount": 62
+    },
+    {
+        "drawTime": "20200403183000",
+        "jackpot": [
+            "$6,325"
+        ],
+        "numbers": "0|3|4|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$6,325"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 28,
+                        "prize": "$506"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 2,
+                        "prize": "$3,425"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 73,
+                        "prize": "$253"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4338",
+        "winnerCount": 103
+    },
+    {
+        "drawTime": "20200402183000",
+        "jackpot": [
+            "$7,450"
+        ],
+        "numbers": "3|7|9|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$7,450"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 25,
+                        "prize": "$298"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$3,892"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 96,
+                        "prize": "$149"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4337",
+        "winnerCount": 125
+    },
+    {
+        "drawTime": "20200401183000",
+        "jackpot": [
+            "$6,992"
+        ],
+        "numbers": "8|2|2|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$6,992"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 3,
+                        "prize": "$1,678"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 2,
+                        "prize": "$4,335"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 12,
+                        "prize": "$839"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4336",
+        "winnerCount": 19
+    },
+    {
+        "drawTime": "20200331183000",
+        "jackpot": [
+            "$9,425"
+        ],
+        "numbers": "0|7|0|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$9,425"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 11,
+                        "prize": "$754"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 2,
+                        "prize": "$5,098"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 46,
+                        "prize": "$377"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4335",
+        "winnerCount": 59
+    },
+    {
+        "drawTime": "20200330183000",
+        "jackpot": [
+            "$2,382"
+        ],
+        "numbers": "3|4|5|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$2,382"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 45,
+                        "prize": "$94"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 14,
+                        "prize": "$1,238"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 126,
+                        "prize": "$47"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4334",
+        "winnerCount": 188
+    },
+    {
+        "drawTime": "20200329183000",
+        "jackpot": [
+            "$5,550"
+        ],
+        "numbers": "5|5|7|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$5,550"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 23,
+                        "prize": "$444"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$3,000"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 46,
+                        "prize": "$222"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4333",
+        "winnerCount": 74
+    },
+    {
+        "drawTime": "20200328183000",
+        "jackpot": [
+            "$3,450"
+        ],
+        "numbers": "1|5|6|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$3,450"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 45,
+                        "prize": "$138"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 9,
+                        "prize": "$1,813"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 226,
+                        "prize": "$69"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4332",
+        "winnerCount": 280
+    },
+    {
+        "drawTime": "20200327183000",
+        "jackpot": [
+            "$3,837"
+        ],
+        "numbers": "5|3|2|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$3,837"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 43,
+                        "prize": "$152"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$1,995"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 138,
+                        "prize": "$76"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4331",
+        "winnerCount": 190
+    },
+    {
+        "drawTime": "20200326183000",
+        "jackpot": [
+            "$5,500"
+        ],
+        "numbers": "9|4|6|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$5,500"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 28,
+                        "prize": "$220"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$2,880"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 95,
+                        "prize": "$110"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4330",
+        "winnerCount": 130
+    },
+    {
+        "drawTime": "20200325183000",
+        "jackpot": [
+            "$5,431"
+        ],
+        "numbers": "8|4|4|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$5,431"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 19,
+                        "prize": "$434"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 2,
+                        "prize": "$2,933"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 51,
+                        "prize": "$217"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4329",
+        "winnerCount": 74
+    },
+    {
+        "drawTime": "20200324183000",
+        "jackpot": [
+            "$6,346"
+        ],
+        "numbers": "0|4|0|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$6,346"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 13,
+                        "prize": "$506"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 2,
+                        "prize": "$3,427"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 61,
+                        "prize": "$253"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4328",
+        "winnerCount": 77
+    },
+    {
+        "drawTime": "20200323183000",
+        "jackpot": [
+            "$2,038"
+        ],
+        "numbers": "8|8|9|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 7,
+                        "prize": "$2,038"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 12,
+                        "prize": "$326"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$1,182"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 53,
+                        "prize": "$163"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4327",
+        "winnerCount": 78
+    },
+    {
+        "drawTime": "20200322183000",
+        "jackpot": [
+            "$1,218"
+        ],
+        "numbers": "5|5|5|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 29,
+                        "prize": "$1,218"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 0,
+                        "prize": "Free play"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 0,
+                        "prize": "Free play"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 0,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4326",
+        "winnerCount": 29
+    },
+    {
+        "drawTime": "20200321183000",
+        "jackpot": [
+            "$9,550"
+        ],
+        "numbers": "3|6|6|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$9,550"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 11,
+                        "prize": "$764"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 2,
+                        "prize": "$5,166"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 49,
+                        "prize": "$382"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4325",
+        "winnerCount": 62
+    },
+    {
+        "drawTime": "20200320183000",
+        "jackpot": [
+            "$5,391"
+        ],
+        "numbers": "6|5|7|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$5,391"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 11,
+                        "prize": "$430"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$2,911"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 50,
+                        "prize": "$215"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4324",
+        "winnerCount": 68
+    },
+    {
+        "drawTime": "20200319183000",
+        "jackpot": [
+            "$4,665"
+        ],
+        "numbers": "2|3|9|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$4,665"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 35,
+                        "prize": "$186"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$2,426"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 161,
+                        "prize": "$93"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4323",
+        "winnerCount": 202
+    },
+    {
+        "drawTime": "20200318183000",
+        "jackpot": [
+            "$4,119"
+        ],
+        "numbers": "5|7|4|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$4,119"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 29,
+                        "prize": "$164"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$2,142"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 198,
+                        "prize": "$82"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4322",
+        "winnerCount": 233
+    },
+    {
+        "drawTime": "20200317183000",
+        "jackpot": [
+            "$8,859"
+        ],
+        "numbers": "0|6|3|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$8,859"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 18,
+                        "prize": "$354"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 1,
+                        "prize": "$4,607"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 102,
+                        "prize": "$177"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4321",
+        "winnerCount": 122
+    },
+    {
+        "drawTime": "20200316183000",
+        "jackpot": [
+            "$6,357"
+        ],
+        "numbers": "3|2|4|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$6,357"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 13,
+                        "prize": "$508"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$3,433"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 43,
+                        "prize": "$254"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4320",
+        "winnerCount": 61
+    },
+    {
+        "drawTime": "20200315183000",
+        "jackpot": [
+            "$6,600"
+        ],
+        "numbers": "4|9|0|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$6,600"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 22,
+                        "prize": "$264"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$3,439"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 131,
+                        "prize": "$132"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4319",
+        "winnerCount": 158
+    },
+    {
+        "drawTime": "20200314183000",
+        "jackpot": [
+            "$4,983"
+        ],
+        "numbers": "4|5|8|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$4,983"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 39,
+                        "prize": "$198"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$2,591"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 104,
+                        "prize": "$99"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4318",
+        "winnerCount": 150
+    },
+    {
+        "drawTime": "20200313183000",
+        "jackpot": [
+            "$5,863"
+        ],
+        "numbers": "0|6|3|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$5,863"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 47,
+                        "prize": "$234"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$3,049"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 154,
+                        "prize": "$117"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4317",
+        "winnerCount": 205
+    },
+    {
+        "drawTime": "20200312183000",
+        "jackpot": [
+            "$13,400"
+        ],
+        "numbers": "3|0|9|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$13,400"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 6,
+                        "prize": "$1,072"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 2,
+                        "prize": "$7,236"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 37,
+                        "prize": "$536"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4316",
+        "winnerCount": 45
+    },
+    {
+        "drawTime": "20200311183000",
+        "jackpot": [
+            "$7,213"
+        ],
+        "numbers": "1|1|8|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$7,213"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 11,
+                        "prize": "$576"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$3,895"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 58,
+                        "prize": "$288"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4315",
+        "winnerCount": 73
+    },
+    {
+        "drawTime": "20200310183000",
+        "jackpot": [
+            "$6,694"
+        ],
+        "numbers": "7|0|1|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$6,694"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 20,
+                        "prize": "$266"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$3,481"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 113,
+                        "prize": "$133"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4314",
+        "winnerCount": 138
+    },
+    {
+        "drawTime": "20200309183000",
+        "jackpot": [
+            "$5,295"
+        ],
+        "numbers": "8|2|9|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$5,295"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 7,
+                        "prize": "$422"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$2,859"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 59,
+                        "prize": "$211"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4313",
+        "winnerCount": 74
+    },
+    {
+        "drawTime": "20200308183000",
+        "jackpot": [
+            "$4,391"
+        ],
+        "numbers": "6|8|2|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$4,391"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 23,
+                        "prize": "$174"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 8,
+                        "prize": "$2,283"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 89,
+                        "prize": "$87"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4312",
+        "winnerCount": 122
+    },
+    {
+        "drawTime": "20200307183000",
+        "jackpot": [
+            "$7,150"
+        ],
+        "numbers": "9|9|1|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$7,150"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 23,
+                        "prize": "$572"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$3,865"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 72,
+                        "prize": "$286"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4311",
+        "winnerCount": 98
+    },
+    {
+        "drawTime": "20200306183000",
+        "jackpot": [
+            "$4,395"
+        ],
+        "numbers": "8|8|7|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$4,395"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 11,
+                        "prize": "$350"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$2,373"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 74,
+                        "prize": "$175"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4310",
+        "winnerCount": 95
+    },
+    {
+        "drawTime": "20200305183000",
+        "jackpot": [
+            "$6,553"
+        ],
+        "numbers": "5|7|1|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$6,553"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 36,
+                        "prize": "$262"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 1,
+                        "prize": "$3,407"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 140,
+                        "prize": "$131"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4309",
+        "winnerCount": 179
+    },
+    {
+        "drawTime": "20200304183000",
+        "jackpot": [
+            "$4,691"
+        ],
+        "numbers": "7|7|0|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$4,691"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 12,
+                        "prize": "$374"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 10,
+                        "prize": "$2,533"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 48,
+                        "prize": "$187"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4308",
+        "winnerCount": 71
+    },
+    {
+        "drawTime": "20200303183000",
+        "jackpot": [
+            "$3,108"
+        ],
+        "numbers": "5|9|4|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$3,108"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 51,
+                        "prize": "$124"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 14,
+                        "prize": "$1,616"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 150,
+                        "prize": "$62"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4307",
+        "winnerCount": 217
+    },
+    {
+        "drawTime": "20200302183000",
+        "jackpot": [
+            "$4,595"
+        ],
+        "numbers": "7|1|6|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 4,
+                        "prize": "$4,595"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 23,
+                        "prize": "$182"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$2,389"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 113,
+                        "prize": "$91"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4306",
+        "winnerCount": 144
+    },
+    {
+        "drawTime": "20200301183000",
+        "jackpot": [
+            "$3,998"
+        ],
+        "numbers": "7|9|9|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$3,998"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 4,
+                        "prize": "$318"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 13,
+                        "prize": "$2,159"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 54,
+                        "prize": "$159"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4305",
+        "winnerCount": 72
+    },
+    {
+        "drawTime": "20200229183000",
+        "jackpot": [
+            "$4,180"
+        ],
+        "numbers": "1|7|5|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$4,180"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 9,
+                        "prize": "$334"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 11,
+                        "prize": "$2,257"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 62,
+                        "prize": "$167"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4304",
+        "winnerCount": 84
+    },
+    {
+        "drawTime": "20200228183000",
+        "jackpot": [
+            "$6,450"
+        ],
+        "numbers": "3|2|7|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$6,450"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 32,
+                        "prize": "$258"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$3,371"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 120,
+                        "prize": "$129"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4303",
+        "winnerCount": 159
+    },
+    {
+        "drawTime": "20200227183000",
+        "jackpot": [
+            "$4,451"
+        ],
+        "numbers": "3|2|2|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$4,451"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 26,
+                        "prize": "$356"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$2,404"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 66,
+                        "prize": "$178"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4302",
+        "winnerCount": 99
+    },
+    {
+        "drawTime": "20200226183000",
+        "jackpot": [
+            "$7,252"
+        ],
+        "numbers": "0|8|5|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$7,252"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 27,
+                        "prize": "$290"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$3,771"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 114,
+                        "prize": "$145"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4301",
+        "winnerCount": 145
+    },
+    {
+        "drawTime": "20200225183000",
+        "jackpot": [
+            "$4,378"
+        ],
+        "numbers": "2|1|3|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$4,378"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 37,
+                        "prize": "$174"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 8,
+                        "prize": "$2,276"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 152,
+                        "prize": "$87"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4300",
+        "winnerCount": 198
+    },
+    {
+        "drawTime": "20200224183000",
+        "jackpot": [
+            "$4,214"
+        ],
+        "numbers": "9|5|1|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$4,214"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 30,
+                        "prize": "$168"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 9,
+                        "prize": "$2,191"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 150,
+                        "prize": "$84"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4299",
+        "winnerCount": 190
+    },
+    {
+        "drawTime": "20200223183000",
+        "jackpot": [
+            "$3,751"
+        ],
+        "numbers": "2|0|3|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$3,751"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 50,
+                        "prize": "$150"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$1,950"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 209,
+                        "prize": "$75"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4298",
+        "winnerCount": 267
+    },
+    {
+        "drawTime": "20200222183000",
+        "jackpot": [
+            "$7,553"
+        ],
+        "numbers": "4|6|7|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$7,553"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 9,
+                        "prize": "$604"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$4,078"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 53,
+                        "prize": "$302"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4297",
+        "winnerCount": 67
+    },
+    {
+        "drawTime": "20200221183000",
+        "jackpot": [
+            "$13,025"
+        ],
+        "numbers": "0|4|9|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$13,025"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 4,
+                        "prize": "$1,042"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$7,037"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 40,
+                        "prize": "$521"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4296",
+        "winnerCount": 47
+    },
+    {
+        "drawTime": "20200220183000",
+        "jackpot": [
+            "$3,429"
+        ],
+        "numbers": "7|4|4|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 4,
+                        "prize": "$3,429"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 9,
+                        "prize": "$548"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 8,
+                        "prize": "$1,989"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 38,
+                        "prize": "$274"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4295",
+        "winnerCount": 59
+    },
+    {
+        "drawTime": "20200219183000",
+        "jackpot": [
+            "$5,497"
+        ],
+        "numbers": "0|5|1|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$5,497"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 32,
+                        "prize": "$218"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$2,858"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 111,
+                        "prize": "$109"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4294",
+        "winnerCount": 150
+    },
+    {
+        "drawTime": "20200218183000",
+        "jackpot": [
+            "$4,421"
+        ],
+        "numbers": "5|6|1|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 4,
+                        "prize": "$4,421"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 16,
+                        "prize": "$176"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$2,299"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 114,
+                        "prize": "$88"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4293",
+        "winnerCount": 139
+    },
+    {
+        "drawTime": "20200217183000",
+        "jackpot": [
+            "$3,307"
+        ],
+        "numbers": "0|0|5|0",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$3,307"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 8,
+                        "prize": "$794"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 11,
+                        "prize": "$2,054"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 28,
+                        "prize": "$397"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4292",
+        "winnerCount": 47
+    },
+    {
+        "drawTime": "20200216183000",
+        "jackpot": [
+            "$5,638"
+        ],
+        "numbers": "0|7|9|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 3,
+                        "prize": "$5,638"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 17,
+                        "prize": "$224"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$2,932"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 106,
+                        "prize": "$112"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4291",
+        "winnerCount": 129
+    },
+    {
+        "drawTime": "20200215183000",
+        "jackpot": [
+            "$8,525"
+        ],
+        "numbers": "5|7|3|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$8,525"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 12,
+                        "prize": "$682"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 5,
+                        "prize": "$4,612"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 41,
+                        "prize": "$341"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4290",
+        "winnerCount": 58
+    },
+    {
+        "drawTime": "20200214183000",
+        "jackpot": [
+            "$8,448"
+        ],
+        "numbers": "8|5|3|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$8,448"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 14,
+                        "prize": "$676"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$4,575"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 54,
+                        "prize": "$338"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4289",
+        "winnerCount": 72
+    },
+    {
+        "drawTime": "20200213183000",
+        "jackpot": [
+            "$5,333"
+        ],
+        "numbers": "4|9|9|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$5,333"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 9,
+                        "prize": "$852"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$3,093"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 28,
+                        "prize": "$426"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4288",
+        "winnerCount": 44
+    },
+    {
+        "drawTime": "20200212183000",
+        "jackpot": [
+            "$6,348"
+        ],
+        "numbers": "6|4|4|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$6,348"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 12,
+                        "prize": "$506"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 6,
+                        "prize": "$3,428"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 41,
+                        "prize": "$253"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4287",
+        "winnerCount": 60
+    },
+    {
+        "drawTime": "20200211183000",
+        "jackpot": [
+            "$6,918"
+        ],
+        "numbers": "6|6|0|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$6,918"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 20,
+                        "prize": "$552"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$3,735"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 51,
+                        "prize": "$276"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4286",
+        "winnerCount": 75
+    },
+    {
+        "drawTime": "20200210183000",
+        "jackpot": [
+            "$3,300"
+        ],
+        "numbers": "9|5|6|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$3,300"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 41,
+                        "prize": "$132"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 11,
+                        "prize": "$1,716"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 158,
+                        "prize": "$66"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4285",
+        "winnerCount": 212
+    },
+    {
+        "drawTime": "20200209183000",
+        "jackpot": [
+            "$3,106"
+        ],
+        "numbers": "8|9|9|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 5,
+                        "prize": "$3,106"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 3,
+                        "prize": "$744"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 7,
+                        "prize": "$1,926"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 25,
+                        "prize": "$372"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4284",
+        "winnerCount": 40
+    },
+    {
+        "drawTime": "20200208183000",
+        "jackpot": [
+            "$5,117"
+        ],
+        "numbers": "7|5|6|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 2,
+                        "prize": "$5,117"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 26,
+                        "prize": "$204"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 8,
+                        "prize": "$2,661"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 90,
+                        "prize": "$102"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4283",
+        "winnerCount": 126
+    },
+    {
+        "drawTime": "20200207183000",
+        "jackpot": [
+            "$6,536"
+        ],
+        "numbers": "5|0|0|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 1,
+                        "prize": "$6,536"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 11,
+                        "prize": "$522"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 4,
+                        "prize": "$3,529"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 80,
+                        "prize": "$261"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4282",
+        "winnerCount": 96
+    },
+    {
+        "drawTime": "20200206183000",
+        "jackpot": [
+            "$9,650"
+        ],
+        "numbers": "8|6|0|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Straight",
+                        "count": 0,
+                        "prize": "$9,650"
+                    },
+                    {
+                        "name": "Box",
+                        "count": 15,
+                        "prize": "$772"
+                    },
+                    {
+                        "name": "Straight and Box",
+                        "count": 3,
+                        "prize": "$5,223"
+                    },
+                    {
+                        "name": "Box Only",
+                        "count": 45,
+                        "prize": "$386"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Daily 4",
+        "lotteryID": "us_ca-daily-4",
+        "issue": "4281",
+        "winnerCount": 63
+    }
+]

--- a/crawler/us/ca/history/us_ca-fantasy-5.json
+++ b/crawler/us/ca/history/us_ca-fantasy-5.json
@@ -1,0 +1,7100 @@
+[
+    {
+        "drawTime": "20200805183000",
+        "jackpot": [
+            "$70,000"
+        ],
+        "numbers": "22,26,27,32,39",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$70,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 104,
+                        "prize": "$420"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3347,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 38262,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9769",
+        "winnerCount": 41713
+    },
+    {
+        "drawTime": "20200804183000",
+        "jackpot": [
+            "$36,557"
+        ],
+        "numbers": "6,11,17,24,32",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$36,557"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 140,
+                        "prize": "$314"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4173,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 43680,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9768",
+        "winnerCount": 47995
+    },
+    {
+        "drawTime": "20200803183000",
+        "jackpot": [
+            "$117,097"
+        ],
+        "numbers": "3,5,16,26,27",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 3,
+                        "prize": "$117,097"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 272,
+                        "prize": "$380"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 9009,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 96582,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9767",
+        "winnerCount": 105866
+    },
+    {
+        "drawTime": "20200802183000",
+        "jackpot": [
+            "$175,000"
+        ],
+        "numbers": "1,4,9,13,20",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$175,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 186,
+                        "prize": "$335"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 6145,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 60184,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9766",
+        "winnerCount": 66515
+    },
+    {
+        "drawTime": "20200801183000",
+        "jackpot": [
+            "$78,000"
+        ],
+        "numbers": "2,8,9,13,23",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$78,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 170,
+                        "prize": "$280"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5228,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 50125,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9765",
+        "winnerCount": 55523
+    },
+    {
+        "drawTime": "20200731183000",
+        "jackpot": [
+            "$182,860"
+        ],
+        "numbers": "1,11,14,16,28",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$182,860"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 191,
+                        "prize": "$363"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5905,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 63860,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9764",
+        "winnerCount": 69957
+    },
+    {
+        "drawTime": "20200730183000",
+        "jackpot": [
+            "$69,000"
+        ],
+        "numbers": "1,24,35,36,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$69,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 104,
+                        "prize": "$402"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3125,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 33226,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9763",
+        "winnerCount": 36455
+    },
+    {
+        "drawTime": "20200729183000",
+        "jackpot": [
+            "$170,742"
+        ],
+        "numbers": "11,13,22,31,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$170,742"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 205,
+                        "prize": "$308"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5803,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 59018,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9762",
+        "winnerCount": 65027
+    },
+    {
+        "drawTime": "20200728183000",
+        "jackpot": [
+            "$70,000"
+        ],
+        "numbers": "5,20,28,35,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$70,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 77,
+                        "prize": "$558"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3125,
+                        "prize": "$17"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 37552,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9761",
+        "winnerCount": 40754
+    },
+    {
+        "drawTime": "20200727183000",
+        "jackpot": [
+            "$64,906"
+        ],
+        "numbers": "3,8,16,28,29",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$64,906"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 100,
+                        "prize": "$399"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3780,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 38061,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9760",
+        "winnerCount": 41942
+    },
+    {
+        "drawTime": "20200726183000",
+        "jackpot": [
+            "$66,250"
+        ],
+        "numbers": "9,10,17,30,39",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$66,250"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 97,
+                        "prize": "$402"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3391,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 37425,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9759",
+        "winnerCount": 40914
+    },
+    {
+        "drawTime": "20200725183000",
+        "jackpot": [
+            "$75,475"
+        ],
+        "numbers": "6,7,17,26,27",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$75,475"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 157,
+                        "prize": "$298"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4930,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 47051,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9758",
+        "winnerCount": 52139
+    },
+    {
+        "drawTime": "20200724183000",
+        "jackpot": [
+            "$76,144"
+        ],
+        "numbers": "6,22,25,30,35",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$76,144"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 96,
+                        "prize": "$488"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3603,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 40683,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9757",
+        "winnerCount": 44383
+    },
+    {
+        "drawTime": "20200723183000",
+        "jackpot": [
+            "$68,898"
+        ],
+        "numbers": "12,15,23,25,35",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$68,898"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 118,
+                        "prize": "$359"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3679,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 38556,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9756",
+        "winnerCount": 42354
+    },
+    {
+        "drawTime": "20200722183000",
+        "jackpot": [
+            "$73,269"
+        ],
+        "numbers": "6,12,13,30,31",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$73,269"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 99,
+                        "prize": "$440"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3790,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 40313,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9755",
+        "winnerCount": 44203
+    },
+    {
+        "drawTime": "20200721183000",
+        "jackpot": [
+            "$72,894"
+        ],
+        "numbers": "3,13,25,31,39",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$72,894"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 110,
+                        "prize": "$394"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3874,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 40128,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9754",
+        "winnerCount": 44113
+    },
+    {
+        "drawTime": "20200720183000",
+        "jackpot": [
+            "$160,886"
+        ],
+        "numbers": "13,16,30,33,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$160,886"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 121,
+                        "prize": "$498"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4454,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 50795,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9753",
+        "winnerCount": 55371
+    },
+    {
+        "drawTime": "20200719183000",
+        "jackpot": [
+            "$61,000"
+        ],
+        "numbers": "11,22,23,24,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$61,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 101,
+                        "prize": "$384"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3345,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 36063,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9752",
+        "winnerCount": 39509
+    },
+    {
+        "drawTime": "20200718183000",
+        "jackpot": [
+            "$38,509"
+        ],
+        "numbers": "1,3,8,28,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$38,509"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 100,
+                        "prize": "$472"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4118,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 43485,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9751",
+        "winnerCount": 47705
+    },
+    {
+        "drawTime": "20200717183000",
+        "jackpot": [
+            "$39,351"
+        ],
+        "numbers": "12,16,29,32,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$39,351"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 123,
+                        "prize": "$385"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3383,
+                        "prize": "$17"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 39888,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9750",
+        "winnerCount": 43396
+    },
+    {
+        "drawTime": "20200716183000",
+        "jackpot": [
+            "$37,723"
+        ],
+        "numbers": "1,20,21,24,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$37,723"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 88,
+                        "prize": "$501"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3249,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 37571,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9749",
+        "winnerCount": 40910
+    },
+    {
+        "drawTime": "20200715183000",
+        "jackpot": [
+            "$75,221"
+        ],
+        "numbers": "7,11,27,28,33",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$75,221"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 197,
+                        "prize": "$227"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5089,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 46925,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9748",
+        "winnerCount": 52212
+    },
+    {
+        "drawTime": "20200714183000",
+        "jackpot": [
+            "$181,250"
+        ],
+        "numbers": "10,16,20,23,32",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$181,250"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 206,
+                        "prize": "$325"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5714,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 62779,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9747",
+        "winnerCount": 68700
+    },
+    {
+        "drawTime": "20200713183000",
+        "jackpot": [
+            "$70,000"
+        ],
+        "numbers": "8,11,17,30,32",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$70,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 131,
+                        "prize": "$321"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3843,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 41824,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9746",
+        "winnerCount": 45798
+    },
+    {
+        "drawTime": "20200712183000",
+        "jackpot": [
+            "$353,014"
+        ],
+        "numbers": "5,11,16,19,20",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$353,014"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 284,
+                        "prize": "$351"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 9249,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 96322,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9745",
+        "winnerCount": 105856
+    },
+    {
+        "drawTime": "20200711183000",
+        "jackpot": [
+            "$187,000"
+        ],
+        "numbers": "2,3,8,29,39",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$187,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 211,
+                        "prize": "$335"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 6265,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 66179,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9744",
+        "winnerCount": 72655
+    },
+    {
+        "drawTime": "20200710183000",
+        "jackpot": [
+            "$78,000"
+        ],
+        "numbers": "1,18,19,23,25",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$78,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 117,
+                        "prize": "$406"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4064,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 44723,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9743",
+        "winnerCount": 48904
+    },
+    {
+        "drawTime": "20200709183000",
+        "jackpot": [
+            "$71,614"
+        ],
+        "numbers": "11,19,23,26,32",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$71,614"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 113,
+                        "prize": "$380"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3987,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 41098,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9742",
+        "winnerCount": 45199
+    },
+    {
+        "drawTime": "20200708183000",
+        "jackpot": [
+            "$182,492"
+        ],
+        "numbers": "11,13,24,27,32",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$182,492"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 171,
+                        "prize": "$387"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5677,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 62398,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9741",
+        "winnerCount": 68247
+    },
+    {
+        "drawTime": "20200707183000",
+        "jackpot": [
+            "$73,000"
+        ],
+        "numbers": "14,22,23,29,32",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$73,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 112,
+                        "prize": "$398"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3617,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 40144,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9740",
+        "winnerCount": 43873
+    },
+    {
+        "drawTime": "20200706183000",
+        "jackpot": [
+            "$168,946"
+        ],
+        "numbers": "15,18,21,25,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$168,946"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 164,
+                        "prize": "$376"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4845,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 54155,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9739",
+        "winnerCount": 59165
+    },
+    {
+        "drawTime": "20200705183000",
+        "jackpot": [
+            "$65,000"
+        ],
+        "numbers": "2,10,14,24,27",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$65,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 103,
+                        "prize": "$382"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3879,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 39380,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9738",
+        "winnerCount": 43362
+    },
+    {
+        "drawTime": "20200704183000",
+        "jackpot": [
+            "$177,669"
+        ],
+        "numbers": "4,6,9,29,35",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$177,669"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 224,
+                        "prize": "$453"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 8673,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 92273,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9737",
+        "winnerCount": 101172
+    },
+    {
+        "drawTime": "20200703183000",
+        "jackpot": [
+            "$180,000"
+        ],
+        "numbers": "4,6,36,37,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$180,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 181,
+                        "prize": "$396"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5564,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 60723,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9736",
+        "winnerCount": 66468
+    },
+    {
+        "drawTime": "20200702183000",
+        "jackpot": [
+            "$67,000"
+        ],
+        "numbers": "15,22,25,27,34",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$67,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 120,
+                        "prize": "$370"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3881,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 39998,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9735",
+        "winnerCount": 43999
+    },
+    {
+        "drawTime": "20200701183000",
+        "jackpot": [
+            "$25,035"
+        ],
+        "numbers": "2,10,19,20,23",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 3,
+                        "prize": "$25,035"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 126,
+                        "prize": "$356"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4619,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 45137,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9734",
+        "winnerCount": 49885
+    },
+    {
+        "drawTime": "20200630183000",
+        "jackpot": [
+            "$76,514"
+        ],
+        "numbers": "2,15,17,19,36",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$76,514"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 119,
+                        "prize": "$373"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3694,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 41207,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9733",
+        "winnerCount": 45021
+    },
+    {
+        "drawTime": "20200629183000",
+        "jackpot": [
+            "$82,783"
+        ],
+        "numbers": "9,13,19,20,23",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$82,783"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 184,
+                        "prize": "$334"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5913,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 60184,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9732",
+        "winnerCount": 66283
+    },
+    {
+        "drawTime": "20200628183000",
+        "jackpot": [
+            "$62,000"
+        ],
+        "numbers": "9,28,32,35,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$62,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 93,
+                        "prize": "$427"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 2979,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 33564,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9731",
+        "winnerCount": 36636
+    },
+    {
+        "drawTime": "20200627183000",
+        "jackpot": [
+            "$200,677"
+        ],
+        "numbers": "5,7,24,32,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$200,677"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 157,
+                        "prize": "$461"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5884,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 66280,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9730",
+        "winnerCount": 72322
+    },
+    {
+        "drawTime": "20200626183000",
+        "jackpot": [
+            "$81,000"
+        ],
+        "numbers": "1,10,15,21,26",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$81,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 134,
+                        "prize": "$354"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4615,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 47155,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9729",
+        "winnerCount": 51904
+    },
+    {
+        "drawTime": "20200625183000",
+        "jackpot": [
+            "$117,975"
+        ],
+        "numbers": "7,8,19,28,39",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 3,
+                        "prize": "$117,975"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 305,
+                        "prize": "$349"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 9820,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 101827,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9728",
+        "winnerCount": 111955
+    },
+    {
+        "drawTime": "20200624183000",
+        "jackpot": [
+            "$177,000"
+        ],
+        "numbers": "9,14,16,20,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$177,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 162,
+                        "prize": "$405"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4995,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 56785,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9727",
+        "winnerCount": 61942
+    },
+    {
+        "drawTime": "20200623183000",
+        "jackpot": [
+            "$74,000"
+        ],
+        "numbers": "11,12,17,20,31",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$74,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 123,
+                        "prize": "$353"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3931,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 42645,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9726",
+        "winnerCount": 46699
+    },
+    {
+        "drawTime": "20200622183000",
+        "jackpot": [
+            "$165,904"
+        ],
+        "numbers": "4,12,17,18,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$165,904"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 152,
+                        "prize": "$397"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5048,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 55743,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9725",
+        "winnerCount": 60944
+    },
+    {
+        "drawTime": "20200621183000",
+        "jackpot": [
+            "$64,000"
+        ],
+        "numbers": "7,10,15,29,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$64,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 83,
+                        "prize": "$474"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3281,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 36411,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9724",
+        "winnerCount": 39775
+    },
+    {
+        "drawTime": "20200620183000",
+        "jackpot": [
+            "$78,842"
+        ],
+        "numbers": "4,13,16,21,23",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$78,842"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 125,
+                        "prize": "$374"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4215,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 44547,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9723",
+        "winnerCount": 48888
+    },
+    {
+        "drawTime": "20200619183000",
+        "jackpot": [
+            "$79,728"
+        ],
+        "numbers": "1,7,17,28,33",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$79,728"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 156,
+                        "prize": "$305"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4262,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 44885,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9722",
+        "winnerCount": 49304
+    },
+    {
+        "drawTime": "20200618183000",
+        "jackpot": [
+            "$23,093"
+        ],
+        "numbers": "4,5,19,20,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 3,
+                        "prize": "$23,093"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 101,
+                        "prize": "$422"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3550,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 40044,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9721",
+        "winnerCount": 43698
+    },
+    {
+        "drawTime": "20200617183000",
+        "jackpot": [
+            "$177,886"
+        ],
+        "numbers": "8,23,26,31,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$177,886"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 177,
+                        "prize": "$370"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5362,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 58206,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9720",
+        "winnerCount": 63746
+    },
+    {
+        "drawTime": "20200616183000",
+        "jackpot": [
+            "$72,000"
+        ],
+        "numbers": "15,21,23,24,28",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$72,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 132,
+                        "prize": "$332"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3841,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 40244,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9719",
+        "winnerCount": 44217
+    },
+    {
+        "drawTime": "20200615183000",
+        "jackpot": [
+            "$69,106"
+        ],
+        "numbers": "1,5,13,21,22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$69,106"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 124,
+                        "prize": "$333"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4080,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 41351,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9718",
+        "winnerCount": 45556
+    },
+    {
+        "drawTime": "20200614183000",
+        "jackpot": [
+            "$32,024"
+        ],
+        "numbers": "4,9,16,29,39",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$32,024"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 100,
+                        "prize": "$396"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3548,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 36668,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9717",
+        "winnerCount": 40318
+    },
+    {
+        "drawTime": "20200613183000",
+        "jackpot": [
+            "$75,263"
+        ],
+        "numbers": "10,14,15,22,26",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$75,263"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 155,
+                        "prize": "$301"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4421,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 45953,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9716",
+        "winnerCount": 50530
+    },
+    {
+        "drawTime": "20200612183000",
+        "jackpot": [
+            "$114,690"
+        ],
+        "numbers": "2,3,16,17,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 3,
+                        "prize": "$114,690"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 235,
+                        "prize": "$453"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 8226,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 93342,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9715",
+        "winnerCount": 101806
+    },
+    {
+        "drawTime": "20200611183000",
+        "jackpot": [
+            "$171,000"
+        ],
+        "numbers": "10,15,17,21,34",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$171,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 140,
+                        "prize": "$455"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5255,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 58534,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9714",
+        "winnerCount": 63929
+    },
+    {
+        "drawTime": "20200610183000",
+        "jackpot": [
+            "$70,000"
+        ],
+        "numbers": "2,9,12,14,19",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$70,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 149,
+                        "prize": "$285"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4588,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 44428,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9713",
+        "winnerCount": 49165
+    },
+    {
+        "drawTime": "20200609183000",
+        "jackpot": [
+            "$85,419"
+        ],
+        "numbers": "2,9,10,16,18",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$85,419"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 180,
+                        "prize": "$356"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 6063,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 61740,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9712",
+        "winnerCount": 67985
+    },
+    {
+        "drawTime": "20200608183000",
+        "jackpot": [
+            "$69,000"
+        ],
+        "numbers": "2,13,15,17,29",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$69,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 113,
+                        "prize": "$354"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3456,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 36854,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9711",
+        "winnerCount": 40423
+    },
+    {
+        "drawTime": "20200607183000",
+        "jackpot": [
+            "$63,038"
+        ],
+        "numbers": "2,22,27,32,33",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$63,038"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 113,
+                        "prize": "$347"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3269,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 35049,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9710",
+        "winnerCount": 38432
+    },
+    {
+        "drawTime": "20200606183000",
+        "jackpot": [
+            "$195,505"
+        ],
+        "numbers": "5,10,13,27,35",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$195,505"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 199,
+                        "prize": "$355"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 6243,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 67304,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9709",
+        "winnerCount": 73747
+    },
+    {
+        "drawTime": "20200605183000",
+        "jackpot": [
+            "$82,000"
+        ],
+        "numbers": "2,11,14,18,25",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$82,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 139,
+                        "prize": "$344"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4520,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 46933,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9708",
+        "winnerCount": 51592
+    },
+    {
+        "drawTime": "20200604183000",
+        "jackpot": [
+            "$27,719"
+        ],
+        "numbers": "7,8,22,27,28",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 6,
+                        "prize": "$27,719"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 233,
+                        "prize": "$263"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 6463,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 62632,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9707",
+        "winnerCount": 69334
+    },
+    {
+        "drawTime": "20200603183000",
+        "jackpot": [
+            "$70,000"
+        ],
+        "numbers": "5,12,18,19,23",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$70,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 134,
+                        "prize": "$312"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4278,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 42379,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9706",
+        "winnerCount": 46791
+    },
+    {
+        "drawTime": "20200602183000",
+        "jackpot": [
+            "$70,904"
+        ],
+        "numbers": "5,7,20,24,33",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$70,904"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 97,
+                        "prize": "$440"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3764,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 41150,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9705",
+        "winnerCount": 45012
+    },
+    {
+        "drawTime": "20200601183000",
+        "jackpot": [
+            "$156,366"
+        ],
+        "numbers": "1,3,12,18,24",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$156,366"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 179,
+                        "prize": "$320"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5268,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 55313,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9704",
+        "winnerCount": 60761
+    },
+    {
+        "drawTime": "20200531183000",
+        "jackpot": [
+            "$64,000"
+        ],
+        "numbers": "23,26,31,37,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$64,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 74,
+                        "prize": "$513"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 2917,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 31283,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9703",
+        "winnerCount": 34274
+    },
+    {
+        "drawTime": "20200530183000",
+        "jackpot": [
+            "$37,991"
+        ],
+        "numbers": "2,7,30,31,35",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$37,991"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 107,
+                        "prize": "$429"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3823,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 42364,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9702",
+        "winnerCount": 46296
+    },
+    {
+        "drawTime": "20200529183000",
+        "jackpot": [
+            "$81,268"
+        ],
+        "numbers": "9,13,15,17,29",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$81,268"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 151,
+                        "prize": "$315"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4368,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 46132,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9701",
+        "winnerCount": 50652
+    },
+    {
+        "drawTime": "20200528183000",
+        "jackpot": [
+            "$90,849"
+        ],
+        "numbers": "3,8,22,23,27",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$90,849"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 190,
+                        "prize": "$335"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 6183,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 63674,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9700",
+        "winnerCount": 70049
+    },
+    {
+        "drawTime": "20200527183000",
+        "jackpot": [
+            "$78,000"
+        ],
+        "numbers": "1,10,20,26,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$78,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 96,
+                        "prize": "$443"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3564,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 39771,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9699",
+        "winnerCount": 43431
+    },
+    {
+        "drawTime": "20200526183000",
+        "jackpot": [
+            "$314,231"
+        ],
+        "numbers": "2,11,12,15,22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$314,231"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 389,
+                        "prize": "$246"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 10083,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 93492,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9698",
+        "winnerCount": 103965
+    },
+    {
+        "drawTime": "20200525183000",
+        "jackpot": [
+            "$158,000"
+        ],
+        "numbers": "5,7,26,29,35",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$158,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 148,
+                        "prize": "$384"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4725,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 52650,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9697",
+        "winnerCount": 57523
+    },
+    {
+        "drawTime": "20200524183000",
+        "jackpot": [
+            "$63,000"
+        ],
+        "numbers": "13,17,19,23,26",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$63,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 127,
+                        "prize": "$303"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3620,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 37557,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9696",
+        "winnerCount": 41304
+    },
+    {
+        "drawTime": "20200523183000",
+        "jackpot": [
+            "$80,591"
+        ],
+        "numbers": "9,12,13,28,34",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$80,591"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 99,
+                        "prize": "$472"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3977,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 45054,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9695",
+        "winnerCount": 49131
+    },
+    {
+        "drawTime": "20200522183000",
+        "jackpot": [
+            "$185,163"
+        ],
+        "numbers": "3,4,8,16,24",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$185,163"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 234,
+                        "prize": "$300"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 6785,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 66490,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9694",
+        "winnerCount": 73510
+    },
+    {
+        "drawTime": "20200521183000",
+        "jackpot": [
+            "$70,000"
+        ],
+        "numbers": "10,12,25,31,36",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$70,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 95,
+                        "prize": "$446"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3438,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 38545,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9693",
+        "winnerCount": 42078
+    },
+    {
+        "drawTime": "20200520183000",
+        "jackpot": [
+            "$75,209"
+        ],
+        "numbers": "14,19,24,27,28",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$75,209"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 159,
+                        "prize": "$268"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4113,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 41828,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9692",
+        "winnerCount": 46101
+    },
+    {
+        "drawTime": "20200519183000",
+        "jackpot": [
+            "$318,691"
+        ],
+        "numbers": "18,23,28,36,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$318,691"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 241,
+                        "prize": "$411"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 7755,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 85769,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9691",
+        "winnerCount": 93766
+    },
+    {
+        "drawTime": "20200518183000",
+        "jackpot": [
+            "$160,000"
+        ],
+        "numbers": "4,16,21,31,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$160,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 124,
+                        "prize": "$460"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4323,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 48332,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9690",
+        "winnerCount": 52779
+    },
+    {
+        "drawTime": "20200517183000",
+        "jackpot": [
+            "$64,000"
+        ],
+        "numbers": "5,15,18,30,35",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$64,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 119,
+                        "prize": "$317"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3397,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 34631,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9689",
+        "winnerCount": 38147
+    },
+    {
+        "drawTime": "20200516183000",
+        "jackpot": [
+            "$184,868"
+        ],
+        "numbers": "11,15,20,29,39",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$184,868"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 138,
+                        "prize": "$482"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5270,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 60344,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9688",
+        "winnerCount": 65753
+    },
+    {
+        "drawTime": "20200515183000",
+        "jackpot": [
+            "$78,000"
+        ],
+        "numbers": "7,11,12,22,28",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$78,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 192,
+                        "prize": "$237"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5290,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 49139,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9687",
+        "winnerCount": 54621
+    },
+    {
+        "drawTime": "20200514183000",
+        "jackpot": [
+            "$66,126"
+        ],
+        "numbers": "12,28,34,37,39",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$66,126"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 100,
+                        "prize": "$407"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3282,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 34955,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9686",
+        "winnerCount": 38338
+    },
+    {
+        "drawTime": "20200513183000",
+        "jackpot": [
+            "$34,486"
+        ],
+        "numbers": "7,8,10,15,23",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$34,486"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 142,
+                        "prize": "$294"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4638,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 44138,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9685",
+        "winnerCount": 48920
+    },
+    {
+        "drawTime": "20200512183000",
+        "jackpot": [
+            "$67,655"
+        ],
+        "numbers": "4,9,11,21,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$67,655"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 119,
+                        "prize": "$350"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4151,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 40904,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9684",
+        "winnerCount": 45175
+    },
+    {
+        "drawTime": "20200511183000",
+        "jackpot": [
+            "$63,369"
+        ],
+        "numbers": "6,12,16,28,33",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$63,369"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 87,
+                        "prize": "$440"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3343,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 35093,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9683",
+        "winnerCount": 38524
+    },
+    {
+        "drawTime": "20200510183000",
+        "jackpot": [
+            "$80,708"
+        ],
+        "numbers": "12,15,16,19,28",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$80,708"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 129,
+                        "prize": "$432"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4799,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 50954,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9682",
+        "winnerCount": 55884
+    },
+    {
+        "drawTime": "20200509183000",
+        "jackpot": [
+            "$75,000"
+        ],
+        "numbers": "14,17,19,27,28",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$75,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 123,
+                        "prize": "$358"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4156,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 43233,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9681",
+        "winnerCount": 47512
+    },
+    {
+        "drawTime": "20200508183000",
+        "jackpot": [
+            "$56,985"
+        ],
+        "numbers": "2,3,7,19,20",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 3,
+                        "prize": "$56,985"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 233,
+                        "prize": "$275"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 6580,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 64706,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9680",
+        "winnerCount": 71522
+    },
+    {
+        "drawTime": "20200507183000",
+        "jackpot": [
+            "$70,000"
+        ],
+        "numbers": "8,10,12,14,23",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$70,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 149,
+                        "prize": "$268"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4040,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 40237,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9679",
+        "winnerCount": 44426
+    },
+    {
+        "drawTime": "20200506183000",
+        "jackpot": [
+            "$165,742"
+        ],
+        "numbers": "10,20,22,27,29",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$165,742"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 184,
+                        "prize": "$320"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5388,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 55121,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9678",
+        "winnerCount": 60694
+    },
+    {
+        "drawTime": "20200505183000",
+        "jackpot": [
+            "$74,000"
+        ],
+        "numbers": "8,24,32,33,35",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$74,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 101,
+                        "prize": "$404"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3276,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 35679,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9677",
+        "winnerCount": 39056
+    },
+    {
+        "drawTime": "20200504183000",
+        "jackpot": [
+            "$38,315"
+        ],
+        "numbers": "4,8,21,23,26",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 4,
+                        "prize": "$38,315"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 161,
+                        "prize": "$344"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4937,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 53721,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9676",
+        "winnerCount": 58823
+    },
+    {
+        "drawTime": "20200503183000",
+        "jackpot": [
+            "$65,000"
+        ],
+        "numbers": "5,7,13,27,31",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$65,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 121,
+                        "prize": "$303"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4009,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 38339,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9675",
+        "winnerCount": 42469
+    },
+    {
+        "drawTime": "20200502183000",
+        "jackpot": [
+            "$36,510"
+        ],
+        "numbers": "5,6,7,20,22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$36,510"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 142,
+                        "prize": "$312"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4617,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 45920,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9674",
+        "winnerCount": 50681
+    },
+    {
+        "drawTime": "20200501183000",
+        "jackpot": [
+            "$84,847"
+        ],
+        "numbers": "8,11,19,36,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$84,847"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 143,
+                        "prize": "$453"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5236,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 59053,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9673",
+        "winnerCount": 64434
+    },
+    {
+        "drawTime": "20200430183000",
+        "jackpot": [
+            "$67,000"
+        ],
+        "numbers": "8,16,18,29,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$67,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 86,
+                        "prize": "$452"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3031,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 34122,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9672",
+        "winnerCount": 37239
+    },
+    {
+        "drawTime": "20200429183000",
+        "jackpot": [
+            "$79,992"
+        ],
+        "numbers": "6,9,20,22,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$79,992"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 148,
+                        "prize": "$387"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4700,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 52390,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9671",
+        "winnerCount": 57240
+    },
+    {
+        "drawTime": "20200428183000",
+        "jackpot": [
+            "$73,000"
+        ],
+        "numbers": "3,5,24,35,39",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$73,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 102,
+                        "prize": "$379"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3203,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 36682,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9670",
+        "winnerCount": 39987
+    },
+    {
+        "drawTime": "20200427183000",
+        "jackpot": [
+            "$142,297"
+        ],
+        "numbers": "2,6,24,35,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$142,297"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 102,
+                        "prize": "$516"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3888,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 46132,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9669",
+        "winnerCount": 50123
+    },
+    {
+        "drawTime": "20200426183000",
+        "jackpot": [
+            "$61,000"
+        ],
+        "numbers": "7,30,32,37,39",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$61,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 87,
+                        "prize": "$396"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 2905,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 31350,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9668",
+        "winnerCount": 34342
+    },
+    {
+        "drawTime": "20200425183000",
+        "jackpot": [
+            "$71,875"
+        ],
+        "numbers": "20,23,25,26,30",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 4,
+                        "prize": "$71,875"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 211,
+                        "prize": "$389"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 6744,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 72516,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9667",
+        "winnerCount": 79475
+    },
+    {
+        "drawTime": "20200424183000",
+        "jackpot": [
+            "$168,000"
+        ],
+        "numbers": "2,18,20,30,31",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$168,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 134,
+                        "prize": "$432"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4586,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 51036,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9666",
+        "winnerCount": 55756
+    },
+    {
+        "drawTime": "20200423183000",
+        "jackpot": [
+            "$67,000"
+        ],
+        "numbers": "2,17,18,19,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$67,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 95,
+                        "prize": "$387"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 2999,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 32730,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9665",
+        "winnerCount": 35824
+    },
+    {
+        "drawTime": "20200422183000",
+        "jackpot": [
+            "$150,206"
+        ],
+        "numbers": "3,10,23,37,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$150,206"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 110,
+                        "prize": "$497"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4493,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 49173,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9664",
+        "winnerCount": 53777
+    },
+    {
+        "drawTime": "20200421183000",
+        "jackpot": [
+            "$70,000"
+        ],
+        "numbers": "11,13,17,27,36",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$70,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 127,
+                        "prize": "$298"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3830,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 37266,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9663",
+        "winnerCount": 41223
+    },
+    {
+        "drawTime": "20200420183000",
+        "jackpot": [
+            "$57,058"
+        ],
+        "numbers": "17,26,29,30,31",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$57,058"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 77,
+                        "prize": "$456"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 2679,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 30321,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9662",
+        "winnerCount": 33078
+    },
+    {
+        "drawTime": "20200419183000",
+        "jackpot": [
+            "$28,217"
+        ],
+        "numbers": "5,8,14,31,35",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$28,217"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 88,
+                        "prize": "$383"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 2745,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 31244,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9661",
+        "winnerCount": 34079
+    },
+    {
+        "drawTime": "20200418183000",
+        "jackpot": [
+            "$70,690"
+        ],
+        "numbers": "2,8,10,25,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$70,690"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 104,
+                        "prize": "$397"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3502,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 38716,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9660",
+        "winnerCount": 42323
+    },
+    {
+        "drawTime": "20200417183000",
+        "jackpot": [
+            "$160,800"
+        ],
+        "numbers": "1,3,14,28,34",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$160,800"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 125,
+                        "prize": "$486"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4741,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 54412,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9659",
+        "winnerCount": 59279
+    },
+    {
+        "drawTime": "20200416183000",
+        "jackpot": [
+            "$69,000"
+        ],
+        "numbers": "3,10,12,16,22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$69,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 123,
+                        "prize": "$303"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3725,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 37189,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9658",
+        "winnerCount": 41037
+    },
+    {
+        "drawTime": "20200415183000",
+        "jackpot": [
+            "$151,776"
+        ],
+        "numbers": "3,7,10,17,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$151,776"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 188,
+                        "prize": "$297"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5626,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 53932,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9657",
+        "winnerCount": 59747
+    },
+    {
+        "drawTime": "20200414183000",
+        "jackpot": [
+            "$73,000"
+        ],
+        "numbers": "7,12,22,26,27",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$73,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 121,
+                        "prize": "$301"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3728,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 37939,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9656",
+        "winnerCount": 41788
+    },
+    {
+        "drawTime": "20200413183000",
+        "jackpot": [
+            "$139,061"
+        ],
+        "numbers": "3,8,27,33,34",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$139,061"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 118,
+                        "prize": "$426"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4233,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 46955,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9655",
+        "winnerCount": 51307
+    },
+    {
+        "drawTime": "20200412183000",
+        "jackpot": [
+            "$65,000"
+        ],
+        "numbers": "11,13,16,21,22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$65,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 83,
+                        "prize": "$385"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3319,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 32791,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9654",
+        "winnerCount": 36193
+    },
+    {
+        "drawTime": "20200411183000",
+        "jackpot": [
+            "$131,683"
+        ],
+        "numbers": "7,14,34,35,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$131,683"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 173,
+                        "prize": "$435"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5957,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 65325,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9653",
+        "winnerCount": 71457
+    },
+    {
+        "drawTime": "20200410183000",
+        "jackpot": [
+            "$163,000"
+        ],
+        "numbers": "13,22,27,31,35",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$163,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 121,
+                        "prize": "$445"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4699,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 49178,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9652",
+        "winnerCount": 53998
+    },
+    {
+        "drawTime": "20200409183000",
+        "jackpot": [
+            "$69,000"
+        ],
+        "numbers": "11,13,28,30,32",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$69,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 67,
+                        "prize": "$487"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 2651,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 30234,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9651",
+        "winnerCount": 32952
+    },
+    {
+        "drawTime": "20200408183000",
+        "jackpot": [
+            "$58,171"
+        ],
+        "numbers": "13,15,19,22,28",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$58,171"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 111,
+                        "prize": "$315"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3170,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 34772,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9650",
+        "winnerCount": 38054
+    },
+    {
+        "drawTime": "20200407183000",
+        "jackpot": [
+            "$211,169"
+        ],
+        "numbers": "1,4,20,27,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$211,169"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 237,
+                        "prize": "$443"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 8011,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 91738,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9649",
+        "winnerCount": 99988
+    },
+    {
+        "drawTime": "20200406183000",
+        "jackpot": [
+            "$272,000"
+        ],
+        "numbers": "13,18,20,25,31",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$272,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 181,
+                        "prize": "$369"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5566,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 59354,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9648",
+        "winnerCount": 65101
+    },
+    {
+        "drawTime": "20200405183000",
+        "jackpot": [
+            "$157,000"
+        ],
+        "numbers": "11,19,21,26,30",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$157,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 137,
+                        "prize": "$349"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4169,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 45598,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9647",
+        "winnerCount": 49904
+    },
+    {
+        "drawTime": "20200404183000",
+        "jackpot": [
+            "$76,000"
+        ],
+        "numbers": "22,24,25,32,33",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$76,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 93,
+                        "prize": "$411"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3061,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 33593,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9646",
+        "winnerCount": 36747
+    },
+    {
+        "drawTime": "20200403183000",
+        "jackpot": [
+            "$65,184"
+        ],
+        "numbers": "9,10,17,22,25",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$65,184"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 109,
+                        "prize": "$363"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3680,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 39418,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9645",
+        "winnerCount": 43208
+    },
+    {
+        "drawTime": "20200402183000",
+        "jackpot": [
+            "$134,006"
+        ],
+        "numbers": "13,14,25,26,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$134,006"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 186,
+                        "prize": "$405"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5740,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 64627,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9644",
+        "winnerCount": 70555
+    },
+    {
+        "drawTime": "20200401183000",
+        "jackpot": [
+            "$161,000"
+        ],
+        "numbers": "7,22,30,31,39",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$161,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 112,
+                        "prize": "$467"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4731,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 48568,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9643",
+        "winnerCount": 53411
+    },
+    {
+        "drawTime": "20200331183000",
+        "jackpot": [
+            "$73,000"
+        ],
+        "numbers": "15,17,30,32,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$73,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 74,
+                        "prize": "$477"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 2572,
+                        "prize": "$17"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 30056,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9642",
+        "winnerCount": 32702
+    },
+    {
+        "drawTime": "20200330183000",
+        "jackpot": [
+            "$55,020"
+        ],
+        "numbers": "5,8,15,27,28",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$55,020"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 125,
+                        "prize": "$266"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3454,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 34702,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9641",
+        "winnerCount": 38282
+    },
+    {
+        "drawTime": "20200329183000",
+        "jackpot": [
+            "$444,863"
+        ],
+        "numbers": "7,22,25,28,33",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$444,863"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 255,
+                        "prize": "$414"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 8615,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 94846,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9640",
+        "winnerCount": 103717
+    },
+    {
+        "drawTime": "20200328183000",
+        "jackpot": [
+            "$288,000"
+        ],
+        "numbers": "13,22,24,26,36",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$288,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 197,
+                        "prize": "$390"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 6566,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 67593,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9639",
+        "winnerCount": 74356
+    },
+    {
+        "drawTime": "20200327183000",
+        "jackpot": [
+            "$166,000"
+        ],
+        "numbers": "17,18,20,24,35",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$166,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 114,
+                        "prize": "$494"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4317,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 49162,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9638",
+        "winnerCount": 53593
+    },
+    {
+        "drawTime": "20200326183000",
+        "jackpot": [
+            "$69,000"
+        ],
+        "numbers": "2,7,18,19,35",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$69,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 88,
+                        "prize": "$399"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3100,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 33844,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9637",
+        "winnerCount": 37032
+    },
+    {
+        "drawTime": "20200325183000",
+        "jackpot": [
+            "$129,837"
+        ],
+        "numbers": "19,21,22,34,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$129,837"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 149,
+                        "prize": "$496"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5609,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 64536,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9636",
+        "winnerCount": 70296
+    },
+    {
+        "drawTime": "20200324183000",
+        "jackpot": [
+            "$153,000"
+        ],
+        "numbers": "4,18,19,30,36",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$153,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 128,
+                        "prize": "$407"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4180,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 46901,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9635",
+        "winnerCount": 51209
+    },
+    {
+        "drawTime": "20200323183000",
+        "jackpot": [
+            "$68,000"
+        ],
+        "numbers": "7,15,19,31,39",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$68,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 119,
+                        "prize": "$279"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3047,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 32338,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9634",
+        "winnerCount": 35504
+    },
+    {
+        "drawTime": "20200322183000",
+        "jackpot": [
+            "$136,568"
+        ],
+        "numbers": "2,11,22,27,30",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$136,568"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 218,
+                        "prize": "$328"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 6763,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 68152,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9633",
+        "winnerCount": 75135
+    },
+    {
+        "drawTime": "20200321183000",
+        "jackpot": [
+            "$174,000"
+        ],
+        "numbers": "11,16,17,24,30",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$174,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 146,
+                        "prize": "$384"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4831,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 52739,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9632",
+        "winnerCount": 57716
+    },
+    {
+        "drawTime": "20200320183000",
+        "jackpot": [
+            "$78,000"
+        ],
+        "numbers": "1,23,27,28,33",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$78,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 74,
+                        "prize": "$533"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3170,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 35563,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9631",
+        "winnerCount": 38807
+    },
+    {
+        "drawTime": "20200319183000",
+        "jackpot": [
+            "$152,227"
+        ],
+        "numbers": "1,2,16,21,28",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$152,227"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 134,
+                        "prize": "$414"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4481,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 49718,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9630",
+        "winnerCount": 54334
+    },
+    {
+        "drawTime": "20200318183000",
+        "jackpot": [
+            "$71,000"
+        ],
+        "numbers": "1,5,10,32,36",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$71,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 93,
+                        "prize": "$408"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3095,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 34947,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9629",
+        "winnerCount": 38135
+    },
+    {
+        "drawTime": "20200317183000",
+        "jackpot": [
+            "$159,391"
+        ],
+        "numbers": "7,19,23,25,26",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$159,391"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 163,
+                        "prize": "$351"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5325,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 55910,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9628",
+        "winnerCount": 61399
+    },
+    {
+        "drawTime": "20200316183000",
+        "jackpot": [
+            "$70,000"
+        ],
+        "numbers": "5,6,9,18,20",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$70,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 150,
+                        "prize": "$251"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4303,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 40805,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9627",
+        "winnerCount": 45258
+    },
+    {
+        "drawTime": "20200315183000",
+        "jackpot": [
+            "$111,108"
+        ],
+        "numbers": "26,28,29,32,39",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 5,
+                        "prize": "$111,108"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 347,
+                        "prize": "$394"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 11066,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 116088,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9626",
+        "winnerCount": 127506
+    },
+    {
+        "drawTime": "20200314183000",
+        "jackpot": [
+            "$316,000"
+        ],
+        "numbers": "4,8,12,31,35",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$316,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 260,
+                        "prize": "$368"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 8094,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 86709,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9625",
+        "winnerCount": 95063
+    },
+    {
+        "drawTime": "20200313183000",
+        "jackpot": [
+            "$175,000"
+        ],
+        "numbers": "8,10,28,36,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$175,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 172,
+                        "prize": "$382"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5507,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 57813,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9624",
+        "winnerCount": 63492
+    },
+    {
+        "drawTime": "20200312183000",
+        "jackpot": [
+            "$69,000"
+        ],
+        "numbers": "10,22,33,34,35",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$69,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 87,
+                        "prize": "$446"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3208,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 33556,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9623",
+        "winnerCount": 36851
+    },
+    {
+        "drawTime": "20200311183000",
+        "jackpot": [
+            "$36,870"
+        ],
+        "numbers": "2,13,23,24,30",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$36,870"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 127,
+                        "prize": "$335"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3881,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 39774,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9622",
+        "winnerCount": 43784
+    },
+    {
+        "drawTime": "20200310183000",
+        "jackpot": [
+            "$29,343"
+        ],
+        "numbers": "12,15,17,27,34",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 6,
+                        "prize": "$29,343"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 178,
+                        "prize": "$356"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5631,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 59708,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9621",
+        "winnerCount": 65523
+    },
+    {
+        "drawTime": "20200309183000",
+        "jackpot": [
+            "$72,000"
+        ],
+        "numbers": "2,3,11,16,25",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$72,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 112,
+                        "prize": "$370"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4091,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 42301,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9620",
+        "winnerCount": 46504
+    },
+    {
+        "drawTime": "20200308183000",
+        "jackpot": [
+            "$60,366"
+        ],
+        "numbers": "7,13,23,31,39",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 3,
+                        "prize": "$60,366"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 242,
+                        "prize": "$248"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5736,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 57438,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9619",
+        "winnerCount": 63419
+    },
+    {
+        "drawTime": "20200307183000",
+        "jackpot": [
+            "$83,000"
+        ],
+        "numbers": "4,6,11,16,27",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$83,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 162,
+                        "prize": "$290"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4796,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 48701,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9618",
+        "winnerCount": 53659
+    },
+    {
+        "drawTime": "20200306183000",
+        "jackpot": [
+            "$120,268"
+        ],
+        "numbers": "1,16,17,23,32",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 3,
+                        "prize": "$120,268"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 228,
+                        "prize": "$485"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 8596,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 95592,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9617",
+        "winnerCount": 104419
+    },
+    {
+        "drawTime": "20200305183000",
+        "jackpot": [
+            "$171,000"
+        ],
+        "numbers": "3,8,19,27,36",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$171,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 197,
+                        "prize": "$339"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5993,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 62923,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9616",
+        "winnerCount": 69113
+    },
+    {
+        "drawTime": "20200304183000",
+        "jackpot": [
+            "$71,000"
+        ],
+        "numbers": "17,27,28,30,35",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$71,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 115,
+                        "prize": "$379"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3845,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 39214,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9615",
+        "winnerCount": 43174
+    },
+    {
+        "drawTime": "20200303183000",
+        "jackpot": [
+            "$72,712"
+        ],
+        "numbers": "18,22,26,29,34",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$72,712"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 107,
+                        "prize": "$415"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3565,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 38524,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9614",
+        "winnerCount": 42197
+    },
+    {
+        "drawTime": "20200302183000",
+        "jackpot": [
+            "$65,999"
+        ],
+        "numbers": "9,16,20,24,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$65,999"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 78,
+                        "prize": "$523"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3065,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 35950,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9613",
+        "winnerCount": 39094
+    },
+    {
+        "drawTime": "20200301183000",
+        "jackpot": [
+            "$66,688"
+        ],
+        "numbers": "7,20,22,31,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$66,688"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 87,
+                        "prize": "$454"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3229,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 35878,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9612",
+        "winnerCount": 39195
+    },
+    {
+        "drawTime": "20200229183000",
+        "jackpot": [
+            "$200,231"
+        ],
+        "numbers": "5,17,25,28,33",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$200,231"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 190,
+                        "prize": "$387"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 6270,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 66182,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9611",
+        "winnerCount": 72643
+    },
+    {
+        "drawTime": "20200228183000",
+        "jackpot": [
+            "$81,000"
+        ],
+        "numbers": "1,3,24,26,27",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$81,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 147,
+                        "prize": "$326"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4176,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 47228,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9610",
+        "winnerCount": 51551
+    },
+    {
+        "drawTime": "20200227183000",
+        "jackpot": [
+            "$353,315"
+        ],
+        "numbers": "1,12,22,24,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$353,315"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 286,
+                        "prize": "$378"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 8669,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 96243,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9609",
+        "winnerCount": 105199
+    },
+    {
+        "drawTime": "20200226183000",
+        "jackpot": [
+            "$171,000"
+        ],
+        "numbers": "9,19,23,25,29",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$171,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 219,
+                        "prize": "$295"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 6196,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 60874,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9608",
+        "winnerCount": 67289
+    },
+    {
+        "drawTime": "20200225183000",
+        "jackpot": [
+            "$71,000"
+        ],
+        "numbers": "4,13,14,18,32",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$71,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 93,
+                        "prize": "$459"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3504,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 39000,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9607",
+        "winnerCount": 42597
+    },
+    {
+        "drawTime": "20200224183000",
+        "jackpot": [
+            "$163,677"
+        ],
+        "numbers": "4,13,20,21,33",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$163,677"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 137,
+                        "prize": "$449"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5000,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 55515,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9606",
+        "winnerCount": 60653
+    },
+    {
+        "drawTime": "20200223183000",
+        "jackpot": [
+            "$62,000"
+        ],
+        "numbers": "5,6,24,37,39",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$62,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 85,
+                        "prize": "$455"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3120,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 36335,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9605",
+        "winnerCount": 39540
+    },
+    {
+        "drawTime": "20200222183000",
+        "jackpot": [
+            "$83,565"
+        ],
+        "numbers": "10,21,22,36,39",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$83,565"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 94,
+                        "prize": "$504"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3797,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 44541,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9604",
+        "winnerCount": 48433
+    },
+    {
+        "drawTime": "20200221183000",
+        "jackpot": [
+            "$362,549"
+        ],
+        "numbers": "5,11,21,27,28",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$362,549"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 328,
+                        "prize": "$346"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 10278,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 107350,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9603",
+        "winnerCount": 117957
+    },
+    {
+        "drawTime": "20200220183000",
+        "jackpot": [
+            "$172,000"
+        ],
+        "numbers": "8,22,24,34,36",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$172,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 142,
+                        "prize": "$475"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5574,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 60047,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9602",
+        "winnerCount": 65763
+    },
+    {
+        "drawTime": "20200219183000",
+        "jackpot": [
+            "$71,000"
+        ],
+        "numbers": "3,4,5,30,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$71,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 97,
+                        "prize": "$438"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3877,
+                        "prize": "$13"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 39587,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9601",
+        "winnerCount": 43561
+    },
+    {
+        "drawTime": "20200218183000",
+        "jackpot": [
+            "$170,425"
+        ],
+        "numbers": "3,11,28,34,36",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$170,425"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 156,
+                        "prize": "$411"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5205,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 58023,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9600",
+        "winnerCount": 63385
+    },
+    {
+        "drawTime": "20200217183000",
+        "jackpot": [
+            "$70,000"
+        ],
+        "numbers": "19,24,31,33,36",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$70,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 82,
+                        "prize": "$489"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3091,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 34875,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9599",
+        "winnerCount": 38048
+    },
+    {
+        "drawTime": "20200216183000",
+        "jackpot": [
+            "$87,901"
+        ],
+        "numbers": "6,17,24,35,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$87,901"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 143,
+                        "prize": "$431"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 4592,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 53223,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9598",
+        "winnerCount": 57960
+    },
+    {
+        "drawTime": "20200215183000",
+        "jackpot": [
+            "$76,000"
+        ],
+        "numbers": "14,33,34,37,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$76,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 117,
+                        "prize": "$393"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3452,
+                        "prize": "$16"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 37710,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9597",
+        "winnerCount": 41279
+    },
+    {
+        "drawTime": "20200214183000",
+        "jackpot": [
+            "$75,072"
+        ],
+        "numbers": "12,18,21,32,34",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$75,072"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 127,
+                        "prize": "$368"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3754,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 41294,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9596",
+        "winnerCount": 45176
+    },
+    {
+        "drawTime": "20200213183000",
+        "jackpot": [
+            "$88,498"
+        ],
+        "numbers": "6,7,17,32,34",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$88,498"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 157,
+                        "prize": "$421"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5460,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 60150,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9595",
+        "winnerCount": 65769
+    },
+    {
+        "drawTime": "20200212183000",
+        "jackpot": [
+            "$70,000"
+        ],
+        "numbers": "14,19,24,29,36",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$70,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 119,
+                        "prize": "$358"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3639,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 39224,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9594",
+        "winnerCount": 42982
+    },
+    {
+        "drawTime": "20200211183000",
+        "jackpot": [
+            "$325,464"
+        ],
+        "numbers": "4,17,18,27,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 1,
+                        "prize": "$325,464"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 271,
+                        "prize": "$370"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 8869,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 90039,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9593",
+        "winnerCount": 99180
+    },
+    {
+        "drawTime": "20200210183000",
+        "jackpot": [
+            "$162,000"
+        ],
+        "numbers": "2,6,11,28,34",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$162,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 124,
+                        "prize": "$484"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5303,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 56890,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9592",
+        "winnerCount": 62317
+    },
+    {
+        "drawTime": "20200209183000",
+        "jackpot": [
+            "$66,000"
+        ],
+        "numbers": "3,12,14,25,35",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$66,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 85,
+                        "prize": "$445"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3212,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 35959,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9591",
+        "winnerCount": 39256
+    },
+    {
+        "drawTime": "20200208183000",
+        "jackpot": [
+            "$177,501"
+        ],
+        "numbers": "2,18,20,27,38",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 2,
+                        "prize": "$177,501"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 224,
+                        "prize": "$477"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 8498,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 94094,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9590",
+        "winnerCount": 102818
+    },
+    {
+        "drawTime": "20200207183000",
+        "jackpot": [
+            "$177,000"
+        ],
+        "numbers": "5,6,17,28,30",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$177,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 166,
+                        "prize": "$418"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 5968,
+                        "prize": "$14"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 63788,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9589",
+        "winnerCount": 69922
+    },
+    {
+        "drawTime": "20200206183000",
+        "jackpot": [
+            "$68,000"
+        ],
+        "numbers": "6,7,18,33,37",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "Matched 5 of 5 numbers",
+                        "count": 0,
+                        "prize": "$68,000"
+                    },
+                    {
+                        "name": "Matched 4 of 5 numbers",
+                        "count": 86,
+                        "prize": "$484"
+                    },
+                    {
+                        "name": "Matched 3 of 5 numbers",
+                        "count": 3343,
+                        "prize": "$15"
+                    },
+                    {
+                        "name": "Matched 2 of 5 numbers",
+                        "count": 38211,
+                        "prize": "Free play"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Fantasy 5",
+        "lotteryID": "us_ca-fantasy-5",
+        "issue": "9588",
+        "winnerCount": 41640
+    }
+]

--- a/crawler/us/ca/history/us_ca-mega-millions.json
+++ b/crawler/us/ca/history/us_ca-mega-millions.json
@@ -1,0 +1,6786 @@
+[
+    {
+        "drawTime": "20200804200000",
+        "jackpot": [
+            "$20,000,000"
+        ],
+        "numbers": "2,22,30,42,62|20",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$20,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$159,809"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$22,140"
+                    },
+                    {
+                        "name": "4",
+                        "count": 25,
+                        "prize": "$500"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 70,
+                        "prize": "$203"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1841,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1427,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 11188,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 26331,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1578",
+        "winnerCount": 40883
+    },
+    {
+        "drawTime": "20200731200000",
+        "jackpot": [
+            "$22,000,000"
+        ],
+        "numbers": "12,35,46,48,69|23",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 1,
+                        "prize": "$22,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$79,529"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$11,018"
+                    },
+                    {
+                        "name": "4",
+                        "count": 15,
+                        "prize": "$826"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 64,
+                        "prize": "$220"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1484,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1252,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 10524,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 26464,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1577",
+        "winnerCount": 39804
+    },
+    {
+        "drawTime": "20200728200000",
+        "jackpot": [
+            "$20,000,000"
+        ],
+        "numbers": "17,20,27,31,34|19",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$20,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$332,090"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$5,658"
+                    },
+                    {
+                        "name": "4",
+                        "count": 42,
+                        "prize": "$303"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 61,
+                        "prize": "$237"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2167,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1442,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 11125,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 26631,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1576",
+        "winnerCount": 41471
+    },
+    {
+        "drawTime": "20200724200000",
+        "jackpot": [
+            "$124,000,000"
+        ],
+        "numbers": "8,33,39,54,58|17",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$124,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$250,399"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 3,
+                        "prize": "$5,798"
+                    },
+                    {
+                        "name": "4",
+                        "count": 30,
+                        "prize": "$652"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 100,
+                        "prize": "$222"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2430,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2216,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 17287,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 41759,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1575",
+        "winnerCount": 63825
+    },
+    {
+        "drawTime": "20200721200000",
+        "jackpot": [
+            "$113,000,000"
+        ],
+        "numbers": "14,25,26,41,43|15",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$113,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$124,844"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 3,
+                        "prize": "$11,201"
+                    },
+                    {
+                        "name": "4",
+                        "count": 36,
+                        "prize": "$540"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 103,
+                        "prize": "$214"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2704,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2370,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 17766,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 41935,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1574",
+        "winnerCount": 64917
+    },
+    {
+        "drawTime": "20200717200000",
+        "jackpot": [
+            "$101,000,000"
+        ],
+        "numbers": "12,13,21,46,57|21",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$101,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$991,576"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$16,309"
+                    },
+                    {
+                        "name": "4",
+                        "count": 32,
+                        "prize": "$573"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 103,
+                        "prize": "$202"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2451,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2222,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 16315,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 38680,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1573",
+        "winnerCount": 59804
+    },
+    {
+        "drawTime": "20200714200000",
+        "jackpot": [
+            "$91,000,000"
+        ],
+        "numbers": "6,26,55,56,64|22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$91,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$873,859"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$15,181"
+                    },
+                    {
+                        "name": "4",
+                        "count": 28,
+                        "prize": "$610"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 94,
+                        "prize": "$206"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2151,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1853,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 14865,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 37468,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1572",
+        "winnerCount": 56460
+    },
+    {
+        "drawTime": "20200710200000",
+        "jackpot": [
+            "$83,000,000"
+        ],
+        "numbers": "10,15,20,49,53|22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$83,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$764,282"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$14,339"
+                    },
+                    {
+                        "name": "4",
+                        "count": 51,
+                        "prize": "$316"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 77,
+                        "prize": "$238"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2346,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1926,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 14421,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 34657,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1571",
+        "winnerCount": 53479
+    },
+    {
+        "drawTime": "20200707200000",
+        "jackpot": [
+            "$73,000,000"
+        ],
+        "numbers": "16,20,25,30,43|18",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$73,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$660,779"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$14,151"
+                    },
+                    {
+                        "name": "4",
+                        "count": 38,
+                        "prize": "$419"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 103,
+                        "prize": "$175"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2497,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1764,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 13675,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 33127,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1570",
+        "winnerCount": 51205
+    },
+    {
+        "drawTime": "20200703200000",
+        "jackpot": [
+            "$62,000,000"
+        ],
+        "numbers": "20,40,44,45,50|24",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$62,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$558,637"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$7,033"
+                    },
+                    {
+                        "name": "4",
+                        "count": 27,
+                        "prize": "$586"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 80,
+                        "prize": "$225"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2101,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1598,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 13004,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 33095,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1569",
+        "winnerCount": 49907
+    },
+    {
+        "drawTime": "20200630200000",
+        "jackpot": [
+            "$53,000,000"
+        ],
+        "numbers": "9,16,29,37,53|11",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$53,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$457,108"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 4,
+                        "prize": "$6,646"
+                    },
+                    {
+                        "name": "4",
+                        "count": 38,
+                        "prize": "$405"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 109,
+                        "prize": "$160"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2251,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2164,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 16125,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 37664,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1568",
+        "winnerCount": 58355
+    },
+    {
+        "drawTime": "20200626200000",
+        "jackpot": [
+            "$44,000,000"
+        ],
+        "numbers": "19,33,37,56,57|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$44,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$358,251"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$12,891"
+                    },
+                    {
+                        "name": "4",
+                        "count": 22,
+                        "prize": "$659"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 68,
+                        "prize": "$242"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1833,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1672,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 13666,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 34582,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1567",
+        "winnerCount": 51843
+    },
+    {
+        "drawTime": "20200623200000",
+        "jackpot": [
+            "$35,000,000"
+        ],
+        "numbers": "6,20,37,40,48|15",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$35,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$265,200"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$12,376"
+                    },
+                    {
+                        "name": "4",
+                        "count": 35,
+                        "prize": "$415"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 84,
+                        "prize": "$196"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2002,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1732,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 13334,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 31975,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1566",
+        "winnerCount": 49164
+    },
+    {
+        "drawTime": "20200619200000",
+        "jackpot": [
+            "$26,000,000"
+        ],
+        "numbers": "11,34,36,52,66|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$26,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$172,013"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$11,842"
+                    },
+                    {
+                        "name": "4",
+                        "count": 23,
+                        "prize": "$579"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 65,
+                        "prize": "$233"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1686,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1709,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 14478,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 36269,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1565",
+        "winnerCount": 54230
+    },
+    {
+        "drawTime": "20200616200000",
+        "jackpot": [
+            "$22,000,000"
+        ],
+        "numbers": "21,23,33,35,42|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$22,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$86,534"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 3,
+                        "prize": "$3,996"
+                    },
+                    {
+                        "name": "4",
+                        "count": 26,
+                        "prize": "$519"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 90,
+                        "prize": "$170"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1957,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1694,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 12999,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 31638,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1564",
+        "winnerCount": 48407
+    },
+    {
+        "drawTime": "20200612200000",
+        "jackpot": [
+            "$20,000,000"
+        ],
+        "numbers": "9,14,57,67,70|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$20,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$607,985"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$11,920"
+                    },
+                    {
+                        "name": "4",
+                        "count": 30,
+                        "prize": "$447"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 58,
+                        "prize": "$263"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1502,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1395,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 12127,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 29194,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1563",
+        "winnerCount": 44308
+    },
+    {
+        "drawTime": "20200609200000",
+        "jackpot": [
+            "$410,000,000"
+        ],
+        "numbers": "1,5,9,10,23|22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$410,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$521,943"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 9,
+                        "prize": "$4,519"
+                    },
+                    {
+                        "name": "4",
+                        "count": 297,
+                        "prize": "$154"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 356,
+                        "prize": "$146"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10203,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5867,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 41701,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 98295,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1562",
+        "winnerCount": 156728
+    },
+    {
+        "drawTime": "20200605200000",
+        "jackpot": [
+            "$378,000,000"
+        ],
+        "numbers": "32,35,37,47,55|22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$378,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$228,363"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 3,
+                        "prize": "$10,546"
+                    },
+                    {
+                        "name": "4",
+                        "count": 57,
+                        "prize": "$624"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 175,
+                        "prize": "$231"
+                    },
+                    {
+                        "name": "3",
+                        "count": 4597,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 3988,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 31380,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 78170,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1561",
+        "winnerCount": 118370
+    },
+    {
+        "drawTime": "20200602200000",
+        "jackpot": [
+            "$356,000,000"
+        ],
+        "numbers": "9,20,23,26,29|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$356,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$221,687"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 8,
+                        "prize": "$3,839"
+                    },
+                    {
+                        "name": "4",
+                        "count": 100,
+                        "prize": "$345"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 319,
+                        "prize": "$123"
+                    },
+                    {
+                        "name": "3",
+                        "count": 5818,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5156,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 35876,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 81810,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1560",
+        "winnerCount": 129088
+    },
+    {
+        "drawTime": "20200529200000",
+        "jackpot": [
+            "$336,000,000"
+        ],
+        "numbers": "10,13,32,41,51|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$336,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$947,631"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 4,
+                        "prize": "$7,328"
+                    },
+                    {
+                        "name": "4",
+                        "count": 74,
+                        "prize": "$445"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 193,
+                        "prize": "$194"
+                    },
+                    {
+                        "name": "3",
+                        "count": 4406,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 3963,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 31185,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 75590,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1559",
+        "winnerCount": 115416
+    },
+    {
+        "drawTime": "20200526200000",
+        "jackpot": [
+            "$313,000,000"
+        ],
+        "numbers": "34,52,58,59,62|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$313,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$736,054"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 3,
+                        "prize": "$9,310"
+                    },
+                    {
+                        "name": "4",
+                        "count": 61,
+                        "prize": "$515"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 161,
+                        "prize": "$222"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3862,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 3464,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 27407,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 73042,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1558",
+        "winnerCount": 108000
+    },
+    {
+        "drawTime": "20200522200000",
+        "jackpot": [
+            "$298,000,000"
+        ],
+        "numbers": "8,10,20,44,46|18",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$298,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$534,453"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$13,223"
+                    },
+                    {
+                        "name": "4",
+                        "count": 68,
+                        "prize": "$437"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 136,
+                        "prize": "$248"
+                    },
+                    {
+                        "name": "3",
+                        "count": 4512,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 3493,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 26706,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 62972,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1557",
+        "winnerCount": 97889
+    },
+    {
+        "drawTime": "20200519200000",
+        "jackpot": [
+            "$274,000,000"
+        ],
+        "numbers": "8,19,25,36,66|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$274,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$343,567"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 3,
+                        "prize": "$8,242"
+                    },
+                    {
+                        "name": "4",
+                        "count": 48,
+                        "prize": "$579"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 174,
+                        "prize": "$181"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3944,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 3986,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 28876,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 67352,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1556",
+        "winnerCount": 104383
+    },
+    {
+        "drawTime": "20200515200000",
+        "jackpot": [
+            "$266,000,000"
+        ],
+        "numbers": "11,17,32,33,46|25",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$266,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$165,097"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$22,873"
+                    },
+                    {
+                        "name": "4",
+                        "count": 68,
+                        "prize": "$378"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 148,
+                        "prize": "$197"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3841,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2983,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 22865,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 55087,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1555",
+        "winnerCount": 84993
+    },
+    {
+        "drawTime": "20200512200000",
+        "jackpot": [
+            "$248,000,000"
+        ],
+        "numbers": "7,16,27,44,52|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$248,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$309,694"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$11,258"
+                    },
+                    {
+                        "name": "4",
+                        "count": 40,
+                        "prize": "$633"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 165,
+                        "prize": "$174"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3597,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 3386,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 25124,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 59011,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1554",
+        "winnerCount": 91326
+    },
+    {
+        "drawTime": "20200508200000",
+        "jackpot": [
+            "$231,000,000"
+        ],
+        "numbers": "5,20,22,61,70|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$231,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$147,173"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 3,
+                        "prize": "$6,796"
+                    },
+                    {
+                        "name": "4",
+                        "count": 38,
+                        "prize": "$604"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 145,
+                        "prize": "$180"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3091,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2756,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 21643,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 51857,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1553",
+        "winnerCount": 79533
+    },
+    {
+        "drawTime": "20200505200000",
+        "jackpot": [
+            "$215,000,000"
+        ],
+        "numbers": "7,13,17,21,45|14",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$215,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$2,171,698"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$20,324"
+                    },
+                    {
+                        "name": "4",
+                        "count": 80,
+                        "prize": "$285"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 159,
+                        "prize": "$163"
+                    },
+                    {
+                        "name": "3",
+                        "count": 4248,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2890,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 20877,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 49070,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1552",
+        "winnerCount": 77326
+    },
+    {
+        "drawTime": "20200501200000",
+        "jackpot": [
+            "$200,000,000"
+        ],
+        "numbers": "28,30,31,35,66|14",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$200,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$2,025,002"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 4,
+                        "prize": "$4,889"
+                    },
+                    {
+                        "name": "4",
+                        "count": 46,
+                        "prize": "$478"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 111,
+                        "prize": "$225"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2967,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2462,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 19587,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 47593,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1551",
+        "winnerCount": 72770
+    },
+    {
+        "drawTime": "20200428200000",
+        "jackpot": [
+            "$186,000,000"
+        ],
+        "numbers": "13,19,53,54,63|17",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$186,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,883,825"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$16,504"
+                    },
+                    {
+                        "name": "4",
+                        "count": 38,
+                        "prize": "$488"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 105,
+                        "prize": "$201"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2429,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2083,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 16168,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 39794,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1550",
+        "winnerCount": 60618
+    },
+    {
+        "drawTime": "20200424200000",
+        "jackpot": [
+            "$174,000,000"
+        ],
+        "numbers": "1,27,32,60,67|18",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$174,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,764,700"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 3,
+                        "prize": "$5,100"
+                    },
+                    {
+                        "name": "4",
+                        "count": 24,
+                        "prize": "$717"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 77,
+                        "prize": "$254"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2089,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1811,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 14562,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 36300,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1549",
+        "winnerCount": 54866
+    },
+    {
+        "drawTime": "20200421200000",
+        "jackpot": [
+            "$164,000,000"
+        ],
+        "numbers": "13,15,24,67,70|17",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$164,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,654,256"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$15,209"
+                    },
+                    {
+                        "name": "4",
+                        "count": 31,
+                        "prize": "$552"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 87,
+                        "prize": "$223"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2087,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1865,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 14641,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 36123,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1548",
+        "winnerCount": 54835
+    },
+    {
+        "drawTime": "20200417200000",
+        "jackpot": [
+            "$159,000,000"
+        ],
+        "numbers": "13,35,39,46,55|14",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$159,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,544,478"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$7,268"
+                    },
+                    {
+                        "name": "4",
+                        "count": 41,
+                        "prize": "$399"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 85,
+                        "prize": "$218"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2183,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1700,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 14157,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 35473,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1547",
+        "winnerCount": 53641
+    },
+    {
+        "drawTime": "20200414200000",
+        "jackpot": [
+            "$145,000,000"
+        ],
+        "numbers": "29,47,65,69,70|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$145,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,439,547"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 3,
+                        "prize": "$11,996"
+                    },
+                    {
+                        "name": "4",
+                        "count": 30,
+                        "prize": "$502"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 83,
+                        "prize": "$206"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1790,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1794,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 15247,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 41776,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1546",
+        "winnerCount": 60723
+    },
+    {
+        "drawTime": "20200410200000",
+        "jackpot": [
+            "$136,000,000"
+        ],
+        "numbers": "2,11,21,57,60|13",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$136,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,342,860"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$22,592"
+                    },
+                    {
+                        "name": "4",
+                        "count": 28,
+                        "prize": "$469"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 86,
+                        "prize": "$173"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1889,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1824,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 13200,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 31207,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1545",
+        "winnerCount": 48234
+    },
+    {
+        "drawTime": "20200407200000",
+        "jackpot": [
+            "$127,000,000"
+        ],
+        "numbers": "25,33,43,51,68|20",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$127,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,258,486"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$10,902"
+                    },
+                    {
+                        "name": "4",
+                        "count": 27,
+                        "prize": "$454"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 56,
+                        "prize": "$249"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1499,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1272,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 10241,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 26317,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1544",
+        "winnerCount": 39412
+    },
+    {
+        "drawTime": "20200403200000",
+        "jackpot": [
+            "$121,000,000"
+        ],
+        "numbers": "24,38,44,57,58|17",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$121,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,179,790"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$11,383"
+                    },
+                    {
+                        "name": "4",
+                        "count": 18,
+                        "prize": "$711"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 57,
+                        "prize": "$255"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1552,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1350,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 10568,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 26612,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1543",
+        "winnerCount": 40158
+    },
+    {
+        "drawTime": "20200331200000",
+        "jackpot": [
+            "$113,000,000"
+        ],
+        "numbers": "8,17,51,57,70|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$113,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,097,622"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$22,339"
+                    },
+                    {
+                        "name": "4",
+                        "count": 13,
+                        "prize": "$975"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 58,
+                        "prize": "$248"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1647,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1414,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 11367,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 27593,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1542",
+        "winnerCount": 42093
+    },
+    {
+        "drawTime": "20200327200000",
+        "jackpot": [
+            "$107,000,000"
+        ],
+        "numbers": "3,25,28,50,60|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$107,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,016,295"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$11,072"
+                    },
+                    {
+                        "name": "4",
+                        "count": 27,
+                        "prize": "$461"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 63,
+                        "prize": "$224"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1763,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1363,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 11215,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 26332,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1541",
+        "winnerCount": 40763
+    },
+    {
+        "drawTime": "20200324200000",
+        "jackpot": [
+            "$101,000,000"
+        ],
+        "numbers": "2,8,16,18,31|14",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$101,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$936,377"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$11,196"
+                    },
+                    {
+                        "name": "4",
+                        "count": 52,
+                        "prize": "$242"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 99,
+                        "prize": "$144"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2575,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1647,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 11588,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 26294,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1540",
+        "winnerCount": 42256
+    },
+    {
+        "drawTime": "20200320200000",
+        "jackpot": [
+            "$96,000,000"
+        ],
+        "numbers": "34,35,41,45,54|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$96,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$855,560"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$5,492"
+                    },
+                    {
+                        "name": "4",
+                        "count": 20,
+                        "prize": "$618"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 70,
+                        "prize": "$200"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1435,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1385,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 11264,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 30458,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1539",
+        "winnerCount": 44634
+    },
+    {
+        "drawTime": "20200317200000",
+        "jackpot": [
+            "$90,000,000"
+        ],
+        "numbers": "20,27,28,58,59|25",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$90,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$776,276"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$12,591"
+                    },
+                    {
+                        "name": "4",
+                        "count": 28,
+                        "prize": "$506"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 73,
+                        "prize": "$220"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1808,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1428,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 12205,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 30191,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1538",
+        "winnerCount": 45734
+    },
+    {
+        "drawTime": "20200313200000",
+        "jackpot": [
+            "$80,000,000"
+        ],
+        "numbers": "7,22,37,43,44|22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$80,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$685,391"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$26,838"
+                    },
+                    {
+                        "name": "4",
+                        "count": 32,
+                        "prize": "$464"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 78,
+                        "prize": "$216"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2187,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1726,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 13197,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 30953,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1537",
+        "winnerCount": 48174
+    },
+    {
+        "drawTime": "20200310200000",
+        "jackpot": [
+            "$75,000,000"
+        ],
+        "numbers": "6,17,48,54,69|12",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$75,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$590,019"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$13,624"
+                    },
+                    {
+                        "name": "4",
+                        "count": 26,
+                        "prize": "$589"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 105,
+                        "prize": "$166"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1964,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1790,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 14902,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 36652,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1536",
+        "winnerCount": 55439
+    },
+    {
+        "drawTime": "20200306200000",
+        "jackpot": [
+            "$70,000,000"
+        ],
+        "numbers": "15,48,56,58,70|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$70,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$491,677"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 4,
+                        "prize": "$6,935"
+                    },
+                    {
+                        "name": "4",
+                        "count": 26,
+                        "prize": "$592"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 70,
+                        "prize": "$250"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1760,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1615,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 13489,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 36469,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1535",
+        "winnerCount": 53433
+    },
+    {
+        "drawTime": "20200303200000",
+        "jackpot": [
+            "$65,000,000"
+        ],
+        "numbers": "8,12,33,56,64|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$65,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$392,859"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$14,051"
+                    },
+                    {
+                        "name": "4",
+                        "count": 30,
+                        "prize": "$527"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 95,
+                        "prize": "$189"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2165,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1809,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 14812,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 34118,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1534",
+        "winnerCount": 53029
+    },
+    {
+        "drawTime": "20200228200000",
+        "jackpot": [
+            "$60,000,000"
+        ],
+        "numbers": "2,3,14,41,64|17",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$60,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$291,435"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$6,720"
+                    },
+                    {
+                        "name": "4",
+                        "count": 48,
+                        "prize": "$315"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 78,
+                        "prize": "$220"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2130,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1742,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 12946,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 30785,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1533",
+        "winnerCount": 47731
+    },
+    {
+        "drawTime": "20200225200000",
+        "jackpot": [
+            "$55,000,000"
+        ],
+        "numbers": "2,9,43,49,63|15",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$55,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$194,418"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$39,975"
+                    },
+                    {
+                        "name": "4",
+                        "count": 29,
+                        "prize": "$521"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 74,
+                        "prize": "$232"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1955,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1805,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 13879,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 33433,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1532",
+        "winnerCount": 51176
+    },
+    {
+        "drawTime": "20200221200000",
+        "jackpot": [
+            "$50,000,000"
+        ],
+        "numbers": "4,7,13,16,60|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$50,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$97,424"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$26,537"
+                    },
+                    {
+                        "name": "4",
+                        "count": 44,
+                        "prize": "$345"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 122,
+                        "prize": "$141"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2621,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2264,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 15191,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 33778,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1531",
+        "winnerCount": 54020
+    },
+    {
+        "drawTime": "20200218200000",
+        "jackpot": [
+            "$45,000,000"
+        ],
+        "numbers": "6,12,39,61,70|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$45,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$567,187"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$13,039"
+                    },
+                    {
+                        "name": "4",
+                        "count": 26,
+                        "prize": "$564"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 68,
+                        "prize": "$245"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1795,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1718,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 13802,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 32894,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1530",
+        "winnerCount": 50304
+    },
+    {
+        "drawTime": "20200214200000",
+        "jackpot": [
+            "$40,000,000"
+        ],
+        "numbers": "10,32,48,54,55|18",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$40,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$473,067"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$13,408"
+                    },
+                    {
+                        "name": "4",
+                        "count": 25,
+                        "prize": "$603"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 72,
+                        "prize": "$238"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1814,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1542,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 12679,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 30956,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1529",
+        "winnerCount": 47089
+    },
+    {
+        "drawTime": "20200211200000",
+        "jackpot": [
+            "$202,000,000"
+        ],
+        "numbers": "4,6,32,52,64|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$202,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$376,289"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$14,262"
+                    },
+                    {
+                        "name": "4",
+                        "count": 61,
+                        "prize": "$526"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 158,
+                        "prize": "$231"
+                    },
+                    {
+                        "name": "3",
+                        "count": 4136,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 3920,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 30910,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 72591,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1528",
+        "winnerCount": 111778
+    },
+    {
+        "drawTime": "20200207200000",
+        "jackpot": [
+            "$187,000,000"
+        ],
+        "numbers": "9,14,27,36,52|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$187,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$170,403"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$11,804"
+                    },
+                    {
+                        "name": "4",
+                        "count": 71,
+                        "prize": "$374"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 144,
+                        "prize": "$209"
+                    },
+                    {
+                        "name": "3",
+                        "count": 4230,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 3306,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 25010,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 59573,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1527",
+        "winnerCount": 92336
+    },
+    {
+        "drawTime": "20200204200000",
+        "jackpot": [
+            "$168,000,000"
+        ],
+        "numbers": "32,48,50,51,64|10",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$168,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$165,920"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$43,634"
+                    },
+                    {
+                        "name": "4",
+                        "count": 44,
+                        "prize": "$588"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 119,
+                        "prize": "$247"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3120,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2969,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 24470,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 65290,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1526",
+        "winnerCount": 96014
+    },
+    {
+        "drawTime": "20200131200000",
+        "jackpot": [
+            "$155,000,000"
+        ],
+        "numbers": "28,31,33,57,62|19",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$155,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$2,168,310"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$20,647"
+                    },
+                    {
+                        "name": "4",
+                        "count": 44,
+                        "prize": "$528"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 138,
+                        "prize": "$191"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3046,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2565,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 20071,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 50117,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1525",
+        "winnerCount": 75982
+    },
+    {
+        "drawTime": "20200128200000",
+        "jackpot": [
+            "$141,000,000"
+        ],
+        "numbers": "17,36,47,51,62|21",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$141,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$2,019,279"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$20,274"
+                    },
+                    {
+                        "name": "4",
+                        "count": 52,
+                        "prize": "$438"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 121,
+                        "prize": "$214"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2940,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2533,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 19893,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 49555,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1524",
+        "winnerCount": 75095
+    },
+    {
+        "drawTime": "20200124200000",
+        "jackpot": [
+            "$130,000,000"
+        ],
+        "numbers": "3,4,18,23,38|24",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$130,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,872,943"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$18,396"
+                    },
+                    {
+                        "name": "4",
+                        "count": 63,
+                        "prize": "$337"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 119,
+                        "prize": "$203"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3753,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2624,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 19006,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 43946,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1523",
+        "winnerCount": 69513
+    },
+    {
+        "drawTime": "20200121200000",
+        "jackpot": [
+            "$116,000,000"
+        ],
+        "numbers": "16,18,29,31,37|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$116,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,736,446"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$17,881"
+                    },
+                    {
+                        "name": "4",
+                        "count": 63,
+                        "prize": "$319"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 138,
+                        "prize": "$165"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3030,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2719,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 20707,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 48826,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1522",
+        "winnerCount": 75483
+    },
+    {
+        "drawTime": "20200117200000",
+        "jackpot": [
+            "$103,000,000"
+        ],
+        "numbers": "3,25,30,54,70|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$103,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,607,379"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$16,820"
+                    },
+                    {
+                        "name": "4",
+                        "count": 34,
+                        "prize": "$556"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 145,
+                        "prize": "$148"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2501,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2596,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 19915,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 47007,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1521",
+        "winnerCount": 72199
+    },
+    {
+        "drawTime": "20200114200000",
+        "jackpot": [
+            "$91,000,000"
+        ],
+        "numbers": "9,11,13,31,47|11",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$91,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,485,969"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$15,294"
+                    },
+                    {
+                        "name": "4",
+                        "count": 47,
+                        "prize": "$366"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 160,
+                        "prize": "$122"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3054,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2971,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 19291,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 40782,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1520",
+        "winnerCount": 66306
+    },
+    {
+        "drawTime": "20200110200000",
+        "jackpot": [
+            "$80,000,000"
+        ],
+        "numbers": "17,27,49,51,66|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$80,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,375,572"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$7,154"
+                    },
+                    {
+                        "name": "4",
+                        "count": 33,
+                        "prize": "$488"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 82,
+                        "prize": "$223"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2140,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1793,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 14037,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 35264,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1519",
+        "winnerCount": 53351
+    },
+    {
+        "drawTime": "20200107200000",
+        "jackpot": [
+            "$69,000,000"
+        ],
+        "numbers": "25,40,41,52,56|21",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$69,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,272,291"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$7,216"
+                    },
+                    {
+                        "name": "4",
+                        "count": 27,
+                        "prize": "$601"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 94,
+                        "prize": "$196"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2079,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1722,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 13866,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 35046,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1518",
+        "winnerCount": 52836
+    },
+    {
+        "drawTime": "20200103200000",
+        "jackpot": [
+            "$60,000,000"
+        ],
+        "numbers": "37,41,42,53,63|16",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$60,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,168,112"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$13,609"
+                    },
+                    {
+                        "name": "4",
+                        "count": 26,
+                        "prize": "$589"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 77,
+                        "prize": "$226"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1967,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1578,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 12199,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 31056,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1517",
+        "winnerCount": 46904
+    },
+    {
+        "drawTime": "20191231200000",
+        "jackpot": [
+            "$55,000,000"
+        ],
+        "numbers": "30,44,49,53,56|11",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$55,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,069,879"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$14,927"
+                    },
+                    {
+                        "name": "4",
+                        "count": 37,
+                        "prize": "$528"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 106,
+                        "prize": "$209"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2339,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2249,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 18843,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 49532,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1516",
+        "winnerCount": 73108
+    },
+    {
+        "drawTime": "20191227200000",
+        "jackpot": [
+            "$50,000,000"
+        ],
+        "numbers": "17,34,40,63,64|24",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$50,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$944,458"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$12,477"
+                    },
+                    {
+                        "name": "4",
+                        "count": 23,
+                        "prize": "$610"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 63,
+                        "prize": "$253"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1634,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1490,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 11690,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 29186,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1515",
+        "winnerCount": 44086
+    },
+    {
+        "drawTime": "20191224200000",
+        "jackpot": [
+            "$45,000,000"
+        ],
+        "numbers": "27,37,48,63,66|11",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$45,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$854,395"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$15,901"
+                    },
+                    {
+                        "name": "4",
+                        "count": 40,
+                        "prize": "$447"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 123,
+                        "prize": "$165"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2225,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2081,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 17160,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 45393,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1514",
+        "winnerCount": 67023
+    },
+    {
+        "drawTime": "20191220200000",
+        "jackpot": [
+            "$40,000,000"
+        ],
+        "numbers": "3,20,23,35,60|16",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$40,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$739,620"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 3,
+                        "prize": "$4,523"
+                    },
+                    {
+                        "name": "4",
+                        "count": 28,
+                        "prize": "$545"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 76,
+                        "prize": "$228"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2139,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1601,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 12721,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 29787,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1513",
+        "winnerCount": 46355
+    },
+    {
+        "drawTime": "20191217200000",
+        "jackpot": [
+            "$372,000,000"
+        ],
+        "numbers": "22,30,53,55,56|16",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$372,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$641,678"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 6,
+                        "prize": "$7,666"
+                    },
+                    {
+                        "name": "4",
+                        "count": 93,
+                        "prize": "$556"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 226,
+                        "prize": "$260"
+                    },
+                    {
+                        "name": "3",
+                        "count": 6729,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5623,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 43810,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 108154,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1512",
+        "winnerCount": 164641
+    },
+    {
+        "drawTime": "20191213200000",
+        "jackpot": [
+            "$340,000,000"
+        ],
+        "numbers": "17,21,29,39,56|22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$340,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$309,662"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 3,
+                        "prize": "$14,300"
+                    },
+                    {
+                        "name": "4",
+                        "count": 116,
+                        "prize": "$416"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 280,
+                        "prize": "$196"
+                    },
+                    {
+                        "name": "3",
+                        "count": 6653,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5558,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 44148,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 106264,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1511",
+        "winnerCount": 163022
+    },
+    {
+        "drawTime": "20191210200000",
+        "jackpot": [
+            "$314,000,000"
+        ],
+        "numbers": "18,31,46,54,61|25",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$314,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$1,524,986"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 3,
+                        "prize": "$12,998"
+                    },
+                    {
+                        "name": "4",
+                        "count": 84,
+                        "prize": "$522"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 224,
+                        "prize": "$222"
+                    },
+                    {
+                        "name": "3",
+                        "count": 5721,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 4854,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 38633,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 96995,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1510",
+        "winnerCount": 146515
+    },
+    {
+        "drawTime": "20191206200000",
+        "jackpot": [
+            "$285,000,000"
+        ],
+        "numbers": "20,31,40,46,61|20",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$285,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,243,518"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 5,
+                        "prize": "$6,356"
+                    },
+                    {
+                        "name": "4",
+                        "count": 64,
+                        "prize": "$559"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 204,
+                        "prize": "$199"
+                    },
+                    {
+                        "name": "3",
+                        "count": 4442,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 4020,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 31615,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 77810,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1509",
+        "winnerCount": 118160
+    },
+    {
+        "drawTime": "20191203200000",
+        "jackpot": [
+            "$266,000,000"
+        ],
+        "numbers": "23,43,60,63,69|19",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$266,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,014,106"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 4,
+                        "prize": "$7,687"
+                    },
+                    {
+                        "name": "4",
+                        "count": 51,
+                        "prize": "$678"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 176,
+                        "prize": "$223"
+                    },
+                    {
+                        "name": "3",
+                        "count": 4348,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 3754,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 30143,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 76094,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1508",
+        "winnerCount": 114570
+    },
+    {
+        "drawTime": "20191129200000",
+        "jackpot": [
+            "$243,000,000"
+        ],
+        "numbers": "6,8,31,50,65|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$243,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$792,155"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 3,
+                        "prize": "$8,515"
+                    },
+                    {
+                        "name": "4",
+                        "count": 38,
+                        "prize": "$756"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 171,
+                        "prize": "$191"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3902,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 3792,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 29697,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 71063,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1507",
+        "winnerCount": 108666
+    },
+    {
+        "drawTime": "20191126200000",
+        "jackpot": [
+            "$226,000,000"
+        ],
+        "numbers": "8,27,29,38,43|13",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$226,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$607,765"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$14,957"
+                    },
+                    {
+                        "name": "4",
+                        "count": 77,
+                        "prize": "$437"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 195,
+                        "prize": "$196"
+                    },
+                    {
+                        "name": "3",
+                        "count": 4902,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 4263,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 33267,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 77134,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1506",
+        "winnerCount": 119840
+    },
+    {
+        "drawTime": "20191122200000",
+        "jackpot": [
+            "$208,000,000"
+        ],
+        "numbers": "7,12,17,49,53|24",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$208,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$391,839"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 4,
+                        "prize": "$7,136"
+                    },
+                    {
+                        "name": "4",
+                        "count": 90,
+                        "prize": "$357"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 207,
+                        "prize": "$176"
+                    },
+                    {
+                        "name": "3",
+                        "count": 4770,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 3718,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 28446,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 66879,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1505",
+        "winnerCount": 104114
+    },
+    {
+        "drawTime": "20191119200000",
+        "jackpot": [
+            "$192,000,000"
+        ],
+        "numbers": "22,43,44,47,66|22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$192,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$185,785"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$12,869"
+                    },
+                    {
+                        "name": "4",
+                        "count": 61,
+                        "prize": "$475"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 161,
+                        "prize": "$204"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3730,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 3324,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 25659,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 63225,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1504",
+        "winnerCount": 96162
+    },
+    {
+        "drawTime": "20191115200000",
+        "jackpot": [
+            "$178,000,000"
+        ],
+        "numbers": "12,19,34,35,68|20",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$178,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$824,951"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$23,325"
+                    },
+                    {
+                        "name": "4",
+                        "count": 44,
+                        "prize": "$596"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 132,
+                        "prize": "$226"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3427,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2930,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 23147,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 55598,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1503",
+        "winnerCount": 85280
+    },
+    {
+        "drawTime": "20191112200000",
+        "jackpot": [
+            "$163,000,000"
+        ],
+        "numbers": "19,30,44,56,65|24",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$163,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$656,593"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 5,
+                        "prize": "$4,418"
+                    },
+                    {
+                        "name": "4",
+                        "count": 52,
+                        "prize": "$478"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 126,
+                        "prize": "$224"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3171,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2658,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 20747,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 51791,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1502",
+        "winnerCount": 78550
+    },
+    {
+        "drawTime": "20191108200000",
+        "jackpot": [
+            "$145,000,000"
+        ],
+        "numbers": "3,4,10,39,58|14",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$145,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$497,117"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$38,077"
+                    },
+                    {
+                        "name": "4",
+                        "count": 55,
+                        "prize": "$395"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 145,
+                        "prize": "$170"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3261,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2672,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 19845,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 46587,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1501",
+        "winnerCount": 72566
+    },
+    {
+        "drawTime": "20191105200000",
+        "jackpot": [
+            "$127,000,000"
+        ],
+        "numbers": "2,9,24,49,54|19",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$127,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$357,757"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$18,769"
+                    },
+                    {
+                        "name": "4",
+                        "count": 43,
+                        "prize": "$491"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 118,
+                        "prize": "$203"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3031,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2490,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 18977,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 44463,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1500",
+        "winnerCount": 69122
+    },
+    {
+        "drawTime": "20191105200000",
+        "jackpot": [
+            "$127,000,000"
+        ],
+        "numbers": "2,9,24,49,54|19",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$127,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$357,757"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$18,769"
+                    },
+                    {
+                        "name": "4",
+                        "count": 43,
+                        "prize": "$491"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 118,
+                        "prize": "$203"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3031,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2490,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 18977,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 44463,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1500",
+        "winnerCount": 69122
+    },
+    {
+        "drawTime": "20191101200000",
+        "jackpot": [
+            "$118,000,000"
+        ],
+        "numbers": "9,20,36,41,54|22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$118,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$222,279"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 6,
+                        "prize": "$2,599"
+                    },
+                    {
+                        "name": "4",
+                        "count": 29,
+                        "prize": "$605"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 85,
+                        "prize": "$234"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2341,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1892,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 15233,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 37116,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1499",
+        "winnerCount": 56702
+    },
+    {
+        "drawTime": "20191029200000",
+        "jackpot": [
+            "$105,000,000"
+        ],
+        "numbers": "4,9,17,27,39|22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$105,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$109,717"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 3,
+                        "prize": "$5,066"
+                    },
+                    {
+                        "name": "4",
+                        "count": 57,
+                        "prize": "$300"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 120,
+                        "prize": "$162"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3384,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2183,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 15423,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 34843,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1498",
+        "winnerCount": 56013
+    },
+    {
+        "drawTime": "20191025200000",
+        "jackpot": [
+            "$93,000,000"
+        ],
+        "numbers": "16,24,25,52,60|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$93,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$1,765,373"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 3,
+                        "prize": "$4,662"
+                    },
+                    {
+                        "name": "4",
+                        "count": 40,
+                        "prize": "$393"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 85,
+                        "prize": "$210"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2148,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1970,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 15037,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 36478,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1497",
+        "winnerCount": 55762
+    },
+    {
+        "drawTime": "20191022200000",
+        "jackpot": [
+            "$82,000,000"
+        ],
+        "numbers": "5,11,14,23,25|10",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$82,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,664,415"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$14,000"
+                    },
+                    {
+                        "name": "4",
+                        "count": 84,
+                        "prize": "$187"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 173,
+                        "prize": "$103"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3490,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2713,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 17765,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 38076,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1496",
+        "winnerCount": 62302
+    },
+    {
+        "drawTime": "20191018200000",
+        "jackpot": [
+            "$71,000,000"
+        ],
+        "numbers": "18,58,60,65,67|20",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$71,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,563,363"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$13,342"
+                    },
+                    {
+                        "name": "4",
+                        "count": 23,
+                        "prize": "$653"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 71,
+                        "prize": "$240"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1730,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1517,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 12326,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 31583,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1495",
+        "winnerCount": 47251
+    },
+    {
+        "drawTime": "20191015200000",
+        "jackpot": [
+            "$65,000,000"
+        ],
+        "numbers": "4,12,14,35,70|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$65,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,467,061"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$6,678"
+                    },
+                    {
+                        "name": "4",
+                        "count": 26,
+                        "prize": "$578"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 97,
+                        "prize": "$176"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2175,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1956,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 13934,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 31998,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1494",
+        "winnerCount": 50188
+    },
+    {
+        "drawTime": "20191011200000",
+        "jackpot": [
+            "$60,000,000"
+        ],
+        "numbers": "14,22,30,37,60|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$60,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,370,649"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$13,056"
+                    },
+                    {
+                        "name": "4",
+                        "count": 26,
+                        "prize": "$557"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 81,
+                        "prize": "$203"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1987,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1962,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 15389,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 37062,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1493",
+        "winnerCount": 56509
+    },
+    {
+        "drawTime": "20191008200000",
+        "jackpot": [
+            "$55,000,000"
+        ],
+        "numbers": "5,8,10,17,48|23",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$55,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,277,720"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$13,238"
+                    },
+                    {
+                        "name": "4",
+                        "count": 56,
+                        "prize": "$266"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 107,
+                        "prize": "$158"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3155,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1989,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 13410,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 30340,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1492",
+        "winnerCount": 49057
+    },
+    {
+        "drawTime": "20191004200000",
+        "jackpot": [
+            "$50,000,000"
+        ],
+        "numbers": "11,38,44,48,70|17",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$50,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,182,165"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$13,013"
+                    },
+                    {
+                        "name": "4",
+                        "count": 28,
+                        "prize": "$523"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 63,
+                        "prize": "$264"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1902,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1535,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 12348,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 30183,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1491",
+        "winnerCount": 46060
+    },
+    {
+        "drawTime": "20191001200000",
+        "jackpot": [
+            "$45,000,000"
+        ],
+        "numbers": "10,17,39,42,59|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$45,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,088,233"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$25,744"
+                    },
+                    {
+                        "name": "4",
+                        "count": 28,
+                        "prize": "$518"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 86,
+                        "prize": "$191"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1933,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1854,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 14123,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 33520,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1490",
+        "winnerCount": 51545
+    },
+    {
+        "drawTime": "20190927200000",
+        "jackpot": [
+            "$40,000,000"
+        ],
+        "numbers": "12,20,31,43,45|20",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$40,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$995,146"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$12,847"
+                    },
+                    {
+                        "name": "4",
+                        "count": 38,
+                        "prize": "$380"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 79,
+                        "prize": "$208"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2011,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1571,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 12216,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 29787,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1489",
+        "winnerCount": 45702
+    },
+    {
+        "drawTime": "20190924200000",
+        "jackpot": [
+            "$227,000,000"
+        ],
+        "numbers": "6,14,24,42,46|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$227,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$902,415"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 6,
+                        "prize": "$5,069"
+                    },
+                    {
+                        "name": "4",
+                        "count": 80,
+                        "prize": "$428"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 251,
+                        "prize": "$155"
+                    },
+                    {
+                        "name": "3",
+                        "count": 5156,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 4980,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 35654,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 84177,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1488",
+        "winnerCount": 130304
+    },
+    {
+        "drawTime": "20190920200000",
+        "jackpot": [
+            "$211,000,000"
+        ],
+        "numbers": "23,24,42,48,53|22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$211,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$682,849"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$13,744"
+                    },
+                    {
+                        "name": "4",
+                        "count": 72,
+                        "prize": "$429"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 154,
+                        "prize": "$228"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3947,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 3334,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 27256,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 66634,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1487",
+        "winnerCount": 101399
+    },
+    {
+        "drawTime": "20190917200000",
+        "jackpot": [
+            "$192,000,000"
+        ],
+        "numbers": "12,15,30,50,65|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$192,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$484,443"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 5,
+                        "prize": "$4,902"
+                    },
+                    {
+                        "name": "4",
+                        "count": 66,
+                        "prize": "$418"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 134,
+                        "prize": "$234"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3864,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 3227,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 24504,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 59803,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1486",
+        "winnerCount": 91603
+    },
+    {
+        "drawTime": "20190913200000",
+        "jackpot": [
+            "$172,000,000"
+        ],
+        "numbers": "6,16,37,59,62|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$172,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$307,510"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 5,
+                        "prize": "$4,353"
+                    },
+                    {
+                        "name": "4",
+                        "count": 54,
+                        "prize": "$453"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 114,
+                        "prize": "$244"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3269,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2789,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 23209,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 58173,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1485",
+        "winnerCount": 87613
+    },
+    {
+        "drawTime": "20190910200000",
+        "jackpot": [
+            "$154,000,000"
+        ],
+        "numbers": "34,47,48,50,55|24",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$154,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$150,400"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$10,418"
+                    },
+                    {
+                        "name": "4",
+                        "count": 45,
+                        "prize": "$521"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 117,
+                        "prize": "$227"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2846,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2488,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 19382,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 49233,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1484",
+        "winnerCount": 74113
+    },
+    {
+        "drawTime": "20190906200000",
+        "jackpot": [
+            "$139,000,000"
+        ],
+        "numbers": "4,11,13,19,31|10",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$139,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$524,457"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 5,
+                        "prize": "$3,837"
+                    },
+                    {
+                        "name": "4",
+                        "count": 89,
+                        "prize": "$242"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 201,
+                        "prize": "$122"
+                    },
+                    {
+                        "name": "3",
+                        "count": 4378,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 3536,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 23097,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 51063,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1483",
+        "winnerCount": 82370
+    },
+    {
+        "drawTime": "20190903200000",
+        "jackpot": [
+            "$127,000,000"
+        ],
+        "numbers": "13,20,27,61,62|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$127,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$385,964"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$9,082"
+                    },
+                    {
+                        "name": "4",
+                        "count": 38,
+                        "prize": "$538"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 119,
+                        "prize": "$195"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2675,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2515,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 19874,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 48107,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1482",
+        "winnerCount": 73330
+    },
+    {
+        "drawTime": "20190830200000",
+        "jackpot": [
+            "$113,000,000"
+        ],
+        "numbers": "3,9,11,34,39|10",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$113,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$254,854"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$17,801"
+                    },
+                    {
+                        "name": "4",
+                        "count": 61,
+                        "prize": "$328"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 165,
+                        "prize": "$138"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3723,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 3137,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 21803,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 48243,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1481",
+        "winnerCount": 77133
+    },
+    {
+        "drawTime": "20190827200000",
+        "jackpot": [
+            "$103,000,000"
+        ],
+        "numbers": "8,12,23,39,43|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$103,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$126,366"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 1,
+                        "prize": "$17,507"
+                    },
+                    {
+                        "name": "4",
+                        "count": 46,
+                        "prize": "$428"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 172,
+                        "prize": "$130"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3222,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 2697,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 19398,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 44751,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1480",
+        "winnerCount": 70287
+    },
+    {
+        "drawTime": "20190823200000",
+        "jackpot": [
+            "$90,000,000"
+        ],
+        "numbers": "11,15,37,54,68|21",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$90,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$831,275"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$13,947"
+                    },
+                    {
+                        "name": "4",
+                        "count": 38,
+                        "prize": "$433"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 62,
+                        "prize": "$302"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2137,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1914,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 14539,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 34864,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1479",
+        "winnerCount": 53557
+    },
+    {
+        "drawTime": "20190820200000",
+        "jackpot": [
+            "$79,000,000"
+        ],
+        "numbers": "8,14,25,51,63|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$79,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$725,555"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$13,247"
+                    },
+                    {
+                        "name": "4",
+                        "count": 31,
+                        "prize": "$481"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 87,
+                        "prize": "$194"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1986,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1822,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 14410,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 33511,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1478",
+        "winnerCount": 51847
+    },
+    {
+        "drawTime": "20190816200000",
+        "jackpot": [
+            "$70,000,000"
+        ],
+        "numbers": "4,14,24,26,46|14",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$70,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$629,936"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 3,
+                        "prize": "$8,441"
+                    },
+                    {
+                        "name": "4",
+                        "count": 41,
+                        "prize": "$345"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 100,
+                        "prize": "$160"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2464,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1813,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 12962,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 29349,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1477",
+        "winnerCount": 46732
+    },
+    {
+        "drawTime": "20190813200000",
+        "jackpot": [
+            "$65,000,000"
+        ],
+        "numbers": "7,27,31,34,51|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$65,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$539,189"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$12,751"
+                    },
+                    {
+                        "name": "4",
+                        "count": 41,
+                        "prize": "$350"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 99,
+                        "prize": "$164"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2168,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1928,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 14625,
+                        "prize": "$3"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 33860,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1476",
+        "winnerCount": 52721
+    },
+    {
+        "drawTime": "20190809200000",
+        "jackpot": [
+            "$60,000,000"
+        ],
+        "numbers": "15,53,56,59,63|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$60,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$447,147"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 2,
+                        "prize": "$12,601"
+                    },
+                    {
+                        "name": "4",
+                        "count": 29,
+                        "prize": "$486"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 61,
+                        "prize": "$262"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1635,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1405,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 11536,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 31464,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1475",
+        "winnerCount": 46132
+    },
+    {
+        "drawTime": "20190806200000",
+        "jackpot": [
+            "$55,000,000"
+        ],
+        "numbers": "11,17,31,43,55|16",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$55,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$356,748"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 0,
+                        "prize": "$12,679"
+                    },
+                    {
+                        "name": "4",
+                        "count": 37,
+                        "prize": "$385"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 71,
+                        "prize": "$228"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2011,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 1473,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 11666,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 28159,
+                        "prize": "$2"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Mega Millions",
+        "lotteryID": "us_ca-mega-millions",
+        "issue": "1474",
+        "winnerCount": 43417
+    }
+]

--- a/crawler/us/ca/history/us_ca-powerball.json
+++ b/crawler/us/ca/history/us_ca-powerball.json
@@ -1,0 +1,6786 @@
+[
+    {
+        "drawTime": "20200805195900",
+        "jackpot": [
+            "$147,000,000"
+        ],
+        "numbers": "7,14,17,57,65|24",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$147,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$143,126"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$71,771"
+                    },
+                    {
+                        "name": "4",
+                        "count": 48,
+                        "prize": "$381"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 101,
+                        "prize": "$188"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3004,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 2337,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 17432,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 41744,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "765",
+        "winnerCount": 64667
+    },
+    {
+        "drawTime": "20200801195900",
+        "jackpot": [
+            "$137,000,000"
+        ],
+        "numbers": "6,25,36,43,48|24",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$137,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$137,230"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$35,131"
+                    },
+                    {
+                        "name": "4",
+                        "count": 66,
+                        "prize": "$266"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 86,
+                        "prize": "$212"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2841,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 2213,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 16616,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 40023,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "764",
+        "winnerCount": 61846
+    },
+    {
+        "drawTime": "20200729195900",
+        "jackpot": [
+            "$126,000,000"
+        ],
+        "numbers": "7,29,35,40,45|26",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$126,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$440,940"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 3,
+                        "prize": "$10,924"
+                    },
+                    {
+                        "name": "4",
+                        "count": 52,
+                        "prize": "$315"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 114,
+                        "prize": "$149"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2648,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 2051,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 16090,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 37275,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "763",
+        "winnerCount": 58234
+    },
+    {
+        "drawTime": "20200725195900",
+        "jackpot": [
+            "$117,000,000"
+        ],
+        "numbers": "5,21,36,61,62|18",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$117,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$312,925"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 4,
+                        "prize": "$7,274"
+                    },
+                    {
+                        "name": "4",
+                        "count": 35,
+                        "prize": "$415"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 91,
+                        "prize": "$166"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2116,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1804,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 14371,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 34111,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "762",
+        "winnerCount": 52532
+    },
+    {
+        "drawTime": "20200722195900",
+        "jackpot": [
+            "$106,000,000"
+        ],
+        "numbers": "16,25,36,44,55|14",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$106,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$199,254"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 3,
+                        "prize": "$8,713"
+                    },
+                    {
+                        "name": "4",
+                        "count": 35,
+                        "prize": "$373"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 60,
+                        "prize": "$226"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1927,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1744,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 12659,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 30093,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "761",
+        "winnerCount": 46521
+    },
+    {
+        "drawTime": "20200718195900",
+        "jackpot": [
+            "$97,000,000"
+        ],
+        "numbers": "13,16,32,58,59|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$97,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$97,146"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 3,
+                        "prize": "$8,289"
+                    },
+                    {
+                        "name": "4",
+                        "count": 28,
+                        "prize": "$444"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 62,
+                        "prize": "$208"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1844,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1732,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 12913,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 31999,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "760",
+        "winnerCount": 48581
+    },
+    {
+        "drawTime": "20200715195900",
+        "jackpot": [
+            "$87,000,000"
+        ],
+        "numbers": "27,47,61,62,69|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$87,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$599,443"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$22,948"
+                    },
+                    {
+                        "name": "4",
+                        "count": 22,
+                        "prize": "$521"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 68,
+                        "prize": "$175"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1622,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1383,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 10729,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 28321,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "759",
+        "winnerCount": 42147
+    },
+    {
+        "drawTime": "20200711195900",
+        "jackpot": [
+            "$79,000,000"
+        ],
+        "numbers": "14,19,61,62,64|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$79,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$509,801"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$11,634"
+                    },
+                    {
+                        "name": "4",
+                        "count": 20,
+                        "prize": "$581"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 62,
+                        "prize": "$194"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1645,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1370,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 11263,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 28087,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "758",
+        "winnerCount": 42449
+    },
+    {
+        "drawTime": "20200708195900",
+        "jackpot": [
+            "$69,000,000"
+        ],
+        "numbers": "3,10,34,36,62|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$69,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$418,908"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$21,958"
+                    },
+                    {
+                        "name": "4",
+                        "count": 27,
+                        "prize": "$406"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 66,
+                        "prize": "$172"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1705,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1517,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 11754,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 27148,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "757",
+        "winnerCount": 42218
+    },
+    {
+        "drawTime": "20200704195900",
+        "jackpot": [
+            "$60,000,000"
+        ],
+        "numbers": "16,21,27,60,61|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$60,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$333,132"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$44,058"
+                    },
+                    {
+                        "name": "4",
+                        "count": 19,
+                        "prize": "$604"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 65,
+                        "prize": "$183"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1640,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1517,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 11798,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 28210,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "756",
+        "winnerCount": 43250
+    },
+    {
+        "drawTime": "20200701195900",
+        "jackpot": [
+            "$51,000,000"
+        ],
+        "numbers": "15,28,52,53,63|18",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$51,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$243,342"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$21,071"
+                    },
+                    {
+                        "name": "4",
+                        "count": 24,
+                        "prize": "$438"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 55,
+                        "prize": "$199"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1469,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1296,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 10002,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 24515,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "755",
+        "winnerCount": 37361
+    },
+    {
+        "drawTime": "20200627195900",
+        "jackpot": [
+            "$42,000,000"
+        ],
+        "numbers": "9,36,49,56,62|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$42,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$161,032"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$41,224"
+                    },
+                    {
+                        "name": "4",
+                        "count": 21,
+                        "prize": "$507"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 61,
+                        "prize": "$181"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1482,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1341,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 10915,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 27764,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "754",
+        "winnerCount": 41585
+    },
+    {
+        "drawTime": "20200624195900",
+        "jackpot": [
+            "$33,000,000"
+        ],
+        "numbers": "15,22,27,33,46|23",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$33,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$77,740"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$19,901"
+                    },
+                    {
+                        "name": "4",
+                        "count": 32,
+                        "prize": "$310"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 69,
+                        "prize": "$149"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1775,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1275,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 9545,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 22561,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "753",
+        "winnerCount": 35257
+    },
+    {
+        "drawTime": "20200620195900",
+        "jackpot": [
+            "$25,000,000"
+        ],
+        "numbers": "10,31,41,63,67|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$25,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$1,454,375"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$58,268"
+                    },
+                    {
+                        "name": "4",
+                        "count": 29,
+                        "prize": "$345"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 55,
+                        "prize": "$189"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1379,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1254,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 10090,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 25808,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "752",
+        "winnerCount": 38617
+    },
+    {
+        "drawTime": "20200617195900",
+        "jackpot": [
+            "$22,000,000"
+        ],
+        "numbers": "7,10,63,64,68|10",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$22,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,376,120"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$38,235"
+                    },
+                    {
+                        "name": "4",
+                        "count": 23,
+                        "prize": "$415"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 72,
+                        "prize": "$137"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1313,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1260,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 10138,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 23616,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "751",
+        "winnerCount": 36422
+    },
+    {
+        "drawTime": "20200613195900",
+        "jackpot": [
+            "$20,000,000"
+        ],
+        "numbers": "2,12,32,50,65|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$20,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,301,422"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$19,112"
+                    },
+                    {
+                        "name": "4",
+                        "count": 21,
+                        "prize": "$455"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 57,
+                        "prize": "$174"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1405,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1357,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 10093,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 23695,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "750",
+        "winnerCount": 36628
+    },
+    {
+        "drawTime": "20200610195900",
+        "jackpot": [
+            "$22,000,000"
+        ],
+        "numbers": "10,33,41,52,54|18",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$22,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,226,764"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$9,852"
+                    },
+                    {
+                        "name": "4",
+                        "count": 17,
+                        "prize": "$579"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 54,
+                        "prize": "$189"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1368,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1119,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 9517,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 22817,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "749",
+        "winnerCount": 34894
+    },
+    {
+        "drawTime": "20200606195900",
+        "jackpot": [
+            "$20,000,000"
+        ],
+        "numbers": "1,17,38,68,69|18",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$20,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,149,792"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 3,
+                        "prize": "$6,904"
+                    },
+                    {
+                        "name": "4",
+                        "count": 25,
+                        "prize": "$414"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 57,
+                        "prize": "$188"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1504,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1242,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 9917,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 24032,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "748",
+        "winnerCount": 36780
+    },
+    {
+        "drawTime": "20200603195900",
+        "jackpot": [
+            "$135,000,000"
+        ],
+        "numbers": "1,3,26,41,64|17",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$135,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,068,875"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$13,112"
+                    },
+                    {
+                        "name": "4",
+                        "count": 41,
+                        "prize": "$319"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 83,
+                        "prize": "$164"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2073,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1763,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 13024,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 30851,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "747",
+        "winnerCount": 47837
+    },
+    {
+        "drawTime": "20200530195900",
+        "jackpot": [
+            "$125,000,000"
+        ],
+        "numbers": "13,32,41,58,60|14",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$125,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$966,434"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$13,642"
+                    },
+                    {
+                        "name": "4",
+                        "count": 31,
+                        "prize": "$440"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 74,
+                        "prize": "$191"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1910,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1631,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 12736,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 32255,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "746",
+        "winnerCount": 48639
+    },
+    {
+        "drawTime": "20200527195900",
+        "jackpot": [
+            "$114,000,000"
+        ],
+        "numbers": "38,58,59,64,68|21",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$114,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$859,854"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 3,
+                        "prize": "$8,257"
+                    },
+                    {
+                        "name": "4",
+                        "count": 18,
+                        "prize": "$688"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 65,
+                        "prize": "$198"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1646,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1353,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 10639,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 28646,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "745",
+        "winnerCount": 42370
+    },
+    {
+        "drawTime": "20200523195900",
+        "jackpot": [
+            "$104,000,000"
+        ],
+        "numbers": "2,8,18,21,23|16",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$104,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$763,083"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$47,667"
+                    },
+                    {
+                        "name": "4",
+                        "count": 85,
+                        "prize": "$152"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 106,
+                        "prize": "$127"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3204,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1869,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 12841,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 29068,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "744",
+        "winnerCount": 47174
+    },
+    {
+        "drawTime": "20200520195900",
+        "jackpot": [
+            "$95,000,000"
+        ],
+        "numbers": "18,34,40,42,50|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$95,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$661,662"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$21,703"
+                    },
+                    {
+                        "name": "4",
+                        "count": 27,
+                        "prize": "$401"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 68,
+                        "prize": "$165"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1594,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1366,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 10951,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 28341,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "743",
+        "winnerCount": 42347
+    },
+    {
+        "drawTime": "20200516195900",
+        "jackpot": [
+            "$86,000,000"
+        ],
+        "numbers": "8,12,26,39,42|11",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$86,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$576,884"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$57,632"
+                    },
+                    {
+                        "name": "4",
+                        "count": 53,
+                        "prize": "$202"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 98,
+                        "prize": "$113"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2168,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1590,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 11546,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 26212,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "742",
+        "winnerCount": 41669
+    },
+    {
+        "drawTime": "20200513195900",
+        "jackpot": [
+            "$77,000,000"
+        ],
+        "numbers": "39,53,54,56,57|20",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$77,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$492,920"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$93,770"
+                    },
+                    {
+                        "name": "4",
+                        "count": 36,
+                        "prize": "$272"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 54,
+                        "prize": "$188"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1345,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1079,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 8663,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 22860,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "741",
+        "winnerCount": 34037
+    },
+    {
+        "drawTime": "20200509195900",
+        "jackpot": [
+            "$68,000,000"
+        ],
+        "numbers": "12,18,42,48,65|19",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$68,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$416,335"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$74,164"
+                    },
+                    {
+                        "name": "4",
+                        "count": 21,
+                        "prize": "$475"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 64,
+                        "prize": "$162"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1441,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1245,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 9591,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 23315,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "740",
+        "winnerCount": 35677
+    },
+    {
+        "drawTime": "20200506195900",
+        "jackpot": [
+            "$59,000,000"
+        ],
+        "numbers": "7,8,35,50,65|20",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$59,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$338,308"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$54,189"
+                    },
+                    {
+                        "name": "4",
+                        "count": 22,
+                        "prize": "$415"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 45,
+                        "prize": "$211"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1298,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1130,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 8688,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 20407,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "739",
+        "winnerCount": 31590
+    },
+    {
+        "drawTime": "20200502195900",
+        "jackpot": [
+            "$51,000,000"
+        ],
+        "numbers": "13,16,33,58,68|24",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$51,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$266,890"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$35,906"
+                    },
+                    {
+                        "name": "4",
+                        "count": 19,
+                        "prize": "$504"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 60,
+                        "prize": "$165"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1373,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1086,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 9118,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 21592,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "738",
+        "winnerCount": 33248
+    },
+    {
+        "drawTime": "20200429195900",
+        "jackpot": [
+            "$43,000,000"
+        ],
+        "numbers": "2,20,49,61,67|20",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$43,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$192,051"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$16,747"
+                    },
+                    {
+                        "name": "4",
+                        "count": 13,
+                        "prize": "$644"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 41,
+                        "prize": "$212"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1135,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1102,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 8001,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 18610,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "737",
+        "winnerCount": 28902
+    },
+    {
+        "drawTime": "20200425195900",
+        "jackpot": [
+            "$37,000,000"
+        ],
+        "numbers": "1,3,21,47,57|18",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$37,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$126,633"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$64,151"
+                    },
+                    {
+                        "name": "4",
+                        "count": 18,
+                        "prize": "$466"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 48,
+                        "prize": "$181"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1457,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1124,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 8305,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 19331,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "736",
+        "winnerCount": 30284
+    },
+    {
+        "drawTime": "20200422195900",
+        "jackpot": [
+            "$29,000,000"
+        ],
+        "numbers": "1,33,35,40,69|24",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$29,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$61,095"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$47,374"
+                    },
+                    {
+                        "name": "4",
+                        "count": 13,
+                        "prize": "$601"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 51,
+                        "prize": "$159"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1105,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 847,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 7325,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 17716,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "735",
+        "winnerCount": 27057
+    },
+    {
+        "drawTime": "20200418195900",
+        "jackpot": [
+            "$24,000,000"
+        ],
+        "numbers": "4,44,46,56,63|19",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$24,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$64,210"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$31,733"
+                    },
+                    {
+                        "name": "4",
+                        "count": 21,
+                        "prize": "$391"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 41,
+                        "prize": "$208"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1112,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 984,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 7677,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 19069,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "734",
+        "winnerCount": 28905
+    },
+    {
+        "drawTime": "20200415195900",
+        "jackpot": [
+            "$22,000,000"
+        ],
+        "numbers": "10,12,33,36,41|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$22,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$1,710,521"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$15,295"
+                    },
+                    {
+                        "name": "4",
+                        "count": 21,
+                        "prize": "$364"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 52,
+                        "prize": "$152"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1358,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1073,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 7455,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 17032,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "733",
+        "winnerCount": 26992
+    },
+    {
+        "drawTime": "20200411195900",
+        "jackpot": [
+            "$20,000,000"
+        ],
+        "numbers": "22,29,30,42,47|17",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$20,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,650,774"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$16,156"
+                    },
+                    {
+                        "name": "4",
+                        "count": 20,
+                        "prize": "$403"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 40,
+                        "prize": "$209"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1302,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1004,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 7888,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 18890,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "732",
+        "winnerCount": 29145
+    },
+    {
+        "drawTime": "20200408195900",
+        "jackpot": [
+            "$190,000,000"
+        ],
+        "numbers": "2,37,39,48,54|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$190,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,587,663"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$12,869"
+                    },
+                    {
+                        "name": "4",
+                        "count": 31,
+                        "prize": "$415"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 77,
+                        "prize": "$173"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1879,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1564,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 13145,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 33153,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "731",
+        "winnerCount": 49851
+    },
+    {
+        "drawTime": "20200404195900",
+        "jackpot": [
+            "$180,000,000"
+        ],
+        "numbers": "8,31,39,40,43|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$180,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,487,123"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$27,298"
+                    },
+                    {
+                        "name": "4",
+                        "count": 27,
+                        "prize": "$505"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 75,
+                        "prize": "$189"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2124,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1738,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 14116,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 33222,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "730",
+        "winnerCount": 51303
+    },
+    {
+        "drawTime": "20200401195900",
+        "jackpot": [
+            "$170,000,000"
+        ],
+        "numbers": "33,35,45,48,60|16",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$170,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,380,488"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$26,273"
+                    },
+                    {
+                        "name": "4",
+                        "count": 24,
+                        "prize": "$547"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 82,
+                        "prize": "$166"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1821,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1692,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 12181,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 30066,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "729",
+        "winnerCount": 45867
+    },
+    {
+        "drawTime": "20200328195900",
+        "jackpot": [
+            "$160,000,000"
+        ],
+        "numbers": "7,40,48,55,66|11",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$160,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,277,859"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$13,424"
+                    },
+                    {
+                        "name": "4",
+                        "count": 28,
+                        "prize": "$479"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 76,
+                        "prize": "$183"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1900,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1688,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 13645,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 33264,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "728",
+        "winnerCount": 50603
+    },
+    {
+        "drawTime": "20200325195900",
+        "jackpot": [
+            "$150,000,000"
+        ],
+        "numbers": "5,9,27,39,42|16",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$150,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,172,984"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$26,049"
+                    },
+                    {
+                        "name": "4",
+                        "count": 35,
+                        "prize": "$372"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 83,
+                        "prize": "$163"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2474,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1783,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 12874,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 29609,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "727",
+        "winnerCount": 46859
+    },
+    {
+        "drawTime": "20200321195900",
+        "jackpot": [
+            "$140,000,000"
+        ],
+        "numbers": "2,23,40,59,69|13",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$140,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,071,228"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$27,591"
+                    },
+                    {
+                        "name": "4",
+                        "count": 28,
+                        "prize": "$492"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 74,
+                        "prize": "$193"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1951,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1794,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 14430,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 35196,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "726",
+        "winnerCount": 53474
+    },
+    {
+        "drawTime": "20200318195900",
+        "jackpot": [
+            "$130,000,000"
+        ],
+        "numbers": "15,27,44,59,63|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$130,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$963,451"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 3,
+                        "prize": "$9,909"
+                    },
+                    {
+                        "name": "4",
+                        "count": 41,
+                        "prize": "$362"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 93,
+                        "prize": "$166"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2263,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1967,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 15330,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 38010,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "725",
+        "winnerCount": 57707
+    },
+    {
+        "drawTime": "20200314195900",
+        "jackpot": [
+            "$120,000,000"
+        ],
+        "numbers": "9,23,26,30,32|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$120,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$847,324"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 4,
+                        "prize": "$8,402"
+                    },
+                    {
+                        "name": "4",
+                        "count": 42,
+                        "prize": "$400"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 120,
+                        "prize": "$145"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3098,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 2550,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 18328,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 41390,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "724",
+        "winnerCount": 65532
+    },
+    {
+        "drawTime": "20200311195900",
+        "jackpot": [
+            "$110,000,000"
+        ],
+        "numbers": "4,29,49,50,67|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$110,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$716,030"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$16,538"
+                    },
+                    {
+                        "name": "4",
+                        "count": 32,
+                        "prize": "$516"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 90,
+                        "prize": "$190"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2269,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1951,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 15586,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 38744,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "723",
+        "winnerCount": 58674
+    },
+    {
+        "drawTime": "20200307195900",
+        "jackpot": [
+            "$100,000,000"
+        ],
+        "numbers": "7,15,21,33,62|23",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$100,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$586,821"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 3,
+                        "prize": "$11,849"
+                    },
+                    {
+                        "name": "4",
+                        "count": 50,
+                        "prize": "$355"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 101,
+                        "prize": "$182"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3110,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 2326,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 17477,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 40203,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "722",
+        "winnerCount": 63270
+    },
+    {
+        "drawTime": "20200304195900",
+        "jackpot": [
+            "$90,000,000"
+        ],
+        "numbers": "18,43,58,60,68|14",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$90,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$447,965"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$30,168"
+                    },
+                    {
+                        "name": "4",
+                        "count": 28,
+                        "prize": "$538"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 78,
+                        "prize": "$200"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2108,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1734,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 13835,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 35726,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "721",
+        "winnerCount": 53510
+    },
+    {
+        "drawTime": "20200229195900",
+        "jackpot": [
+            "$80,000,000"
+        ],
+        "numbers": "24,44,46,50,51|13",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$80,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$330,121"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$56,942"
+                    },
+                    {
+                        "name": "4",
+                        "count": 28,
+                        "prize": "$531"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 84,
+                        "prize": "$184"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2154,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1882,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 14703,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 38401,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "720",
+        "winnerCount": 57253
+    },
+    {
+        "drawTime": "20200226195900",
+        "jackpot": [
+            "$70,000,000"
+        ],
+        "numbers": "8,27,29,36,47|24",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$70,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$213,888"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$27,186"
+                    },
+                    {
+                        "name": "4",
+                        "count": 34,
+                        "prize": "$399"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 77,
+                        "prize": "$183"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2456,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1739,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 13452,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 30544,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "719",
+        "winnerCount": 48302
+    },
+    {
+        "drawTime": "20200222195900",
+        "jackpot": [
+            "$60,000,000"
+        ],
+        "numbers": "25,37,39,61,62|11",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$60,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$107,690"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$27,569"
+                    },
+                    {
+                        "name": "4",
+                        "count": 29,
+                        "prize": "$475"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 72,
+                        "prize": "$198"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1859,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1621,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 13433,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 34902,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "718",
+        "winnerCount": 51917
+    },
+    {
+        "drawTime": "20200219195900",
+        "jackpot": [
+            "$50,000,000"
+        ],
+        "numbers": "10,12,15,19,56|19",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$50,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$7,054,356"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$12,588"
+                    },
+                    {
+                        "name": "4",
+                        "count": 44,
+                        "prize": "$286"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 81,
+                        "prize": "$161"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2652,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1865,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 12921,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 28528,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "717",
+        "winnerCount": 46094
+    },
+    {
+        "drawTime": "20200215195900",
+        "jackpot": [
+            "$40,000,000"
+        ],
+        "numbers": "16,32,35,36,46|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$40,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$6,956,011"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 4,
+                        "prize": "$6,226"
+                    },
+                    {
+                        "name": "4",
+                        "count": 26,
+                        "prize": "$478"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 90,
+                        "prize": "$143"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1981,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1587,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 12313,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 30621,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "716",
+        "winnerCount": 46622
+    },
+    {
+        "drawTime": "20200212195900",
+        "jackpot": [
+            "$70,000,000"
+        ],
+        "numbers": "14,47,54,55,68|25",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$70,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$6,858,722"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$25,954"
+                    },
+                    {
+                        "name": "4",
+                        "count": 32,
+                        "prize": "$405"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 81,
+                        "prize": "$166"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1827,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1442,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 11694,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 29558,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "715",
+        "winnerCount": 44635
+    },
+    {
+        "drawTime": "20200208195900",
+        "jackpot": [
+            "$60,000,000"
+        ],
+        "numbers": "35,49,50,59,66|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$60,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$6,757,337"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$40,183"
+                    },
+                    {
+                        "name": "4",
+                        "count": 36,
+                        "prize": "$374"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 54,
+                        "prize": "$259"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1785,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1580,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 12553,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 34708,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "714",
+        "winnerCount": 50718
+    },
+    {
+        "drawTime": "20200205195900",
+        "jackpot": [
+            "$50,000,000"
+        ],
+        "numbers": "23,30,35,41,57|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$50,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$6,652,023"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$53,407"
+                    },
+                    {
+                        "name": "4",
+                        "count": 23,
+                        "prize": "$538"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 72,
+                        "prize": "$178"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1912,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1458,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 11499,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 28929,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "713",
+        "winnerCount": 43893
+    },
+    {
+        "drawTime": "20200201195900",
+        "jackpot": [
+            "$40,000,000"
+        ],
+        "numbers": "12,33,54,57,60|13",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$40,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$6,555,195"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$28,619"
+                    },
+                    {
+                        "name": "4",
+                        "count": 28,
+                        "prize": "$511"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 76,
+                        "prize": "$195"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1998,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1800,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 14655,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 36794,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "712",
+        "winnerCount": 55351
+    },
+    {
+        "drawTime": "20200129195900",
+        "jackpot": [
+            "$394,000,000"
+        ],
+        "numbers": "9,12,15,31,60|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$394,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$6,443,402"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 7,
+                        "prize": "$15,103"
+                    },
+                    {
+                        "name": "4",
+                        "count": 131,
+                        "prize": "$403"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 345,
+                        "prize": "$159"
+                    },
+                    {
+                        "name": "3",
+                        "count": 9052,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 7114,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 52081,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 120399,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "711",
+        "winnerCount": 189129
+    },
+    {
+        "drawTime": "20200125195900",
+        "jackpot": [
+            "$373,000,000"
+        ],
+        "numbers": "2,9,17,36,67|18",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$373,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$6,030,425"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 4,
+                        "prize": "$25,084"
+                    },
+                    {
+                        "name": "4",
+                        "count": 106,
+                        "prize": "$473"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 325,
+                        "prize": "$160"
+                    },
+                    {
+                        "name": "3",
+                        "count": 8410,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 6551,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 49632,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 116683,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "710",
+        "winnerCount": 181711
+    },
+    {
+        "drawTime": "20200122195900",
+        "jackpot": [
+            "$343,000,000"
+        ],
+        "numbers": "11,33,44,59,67|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$343,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$5,638,490"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$87,253"
+                    },
+                    {
+                        "name": "4",
+                        "count": 108,
+                        "prize": "$403"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 254,
+                        "prize": "$178"
+                    },
+                    {
+                        "name": "3",
+                        "count": 6886,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 5763,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 44362,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 109373,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "709",
+        "winnerCount": 166747
+    },
+    {
+        "drawTime": "20200118195900",
+        "jackpot": [
+            "$321,000,000"
+        ],
+        "numbers": "20,24,38,56,68|18",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$321,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$5,297,657"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 5,
+                        "prize": "$16,181"
+                    },
+                    {
+                        "name": "4",
+                        "count": 85,
+                        "prize": "$475"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 233,
+                        "prize": "$180"
+                    },
+                    {
+                        "name": "3",
+                        "count": 6021,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 5122,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 39435,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 95238,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "708",
+        "winnerCount": 146139
+    },
+    {
+        "drawTime": "20200115195900",
+        "jackpot": [
+            "$296,000,000"
+        ],
+        "numbers": "39,41,53,55,68|19",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$296,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$4,981,604"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$36,038"
+                    },
+                    {
+                        "name": "4",
+                        "count": 71,
+                        "prize": "$507"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 234,
+                        "prize": "$160"
+                    },
+                    {
+                        "name": "3",
+                        "count": 4974,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 4265,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 33721,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 84949,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "707",
+        "winnerCount": 128216
+    },
+    {
+        "drawTime": "20200111195900",
+        "jackpot": [
+            "$277,000,000"
+        ],
+        "numbers": "3,21,23,31,59|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$277,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$4,700,058"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$65,040"
+                    },
+                    {
+                        "name": "4",
+                        "count": 95,
+                        "prize": "$342"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 225,
+                        "prize": "$150"
+                    },
+                    {
+                        "name": "3",
+                        "count": 5373,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 4774,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 33709,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 76356,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "706",
+        "winnerCount": 120533
+    },
+    {
+        "drawTime": "20200108195900",
+        "jackpot": [
+            "$258,000,000"
+        ],
+        "numbers": "2,4,7,43,56|22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$258,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$4,445,997"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$32,121"
+                    },
+                    {
+                        "name": "4",
+                        "count": 82,
+                        "prize": "$391"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 210,
+                        "prize": "$158"
+                    },
+                    {
+                        "name": "3",
+                        "count": 5779,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 4324,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 31197,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 72163,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "705",
+        "winnerCount": 113757
+    },
+    {
+        "drawTime": "20200104195900",
+        "jackpot": [
+            "$237,000,000"
+        ],
+        "numbers": "1,11,21,25,54|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$237,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$4,195,053"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 4,
+                        "prize": "$31,103"
+                    },
+                    {
+                        "name": "4",
+                        "count": 77,
+                        "prize": "$396"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 285,
+                        "prize": "$111"
+                    },
+                    {
+                        "name": "3",
+                        "count": 5633,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 5021,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 35218,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 77903,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "704",
+        "winnerCount": 124141
+    },
+    {
+        "drawTime": "20200101195900",
+        "jackpot": [
+            "$220,000,000"
+        ],
+        "numbers": "49,53,57,59,62|26",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$220,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$3,956,632"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$63,376"
+                    },
+                    {
+                        "name": "4",
+                        "count": 77,
+                        "prize": "$411"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 207,
+                        "prize": "$159"
+                    },
+                    {
+                        "name": "3",
+                        "count": 4524,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 3789,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 28996,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 74417,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "703",
+        "winnerCount": 112010
+    },
+    {
+        "drawTime": "20191228195900",
+        "jackpot": [
+            "$200,000,000"
+        ],
+        "numbers": "20,23,39,59,60|18",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$200,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$3,709,070"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$53,123"
+                    },
+                    {
+                        "name": "4",
+                        "count": 68,
+                        "prize": "$390"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 162,
+                        "prize": "$170"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3927,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 3225,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 25150,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 61775,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "702",
+        "winnerCount": 94308
+    },
+    {
+        "drawTime": "20191225195900",
+        "jackpot": [
+            "$183,000,000"
+        ],
+        "numbers": "2,4,16,30,46|20",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$183,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$3,501,559"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 4,
+                        "prize": "$12,301"
+                    },
+                    {
+                        "name": "4",
+                        "count": 63,
+                        "prize": "$390"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 194,
+                        "prize": "$131"
+                    },
+                    {
+                        "name": "3",
+                        "count": 4398,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 3322,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 23969,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 55706,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "701",
+        "winnerCount": 87656
+    },
+    {
+        "drawTime": "20191221195900",
+        "jackpot": [
+            "$171,000,000"
+        ],
+        "numbers": "19,31,35,50,67|14",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$171,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$3,309,348"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 3,
+                        "prize": "$13,784"
+                    },
+                    {
+                        "name": "4",
+                        "count": 35,
+                        "prize": "$590"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 108,
+                        "prize": "$198"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3039,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 2460,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 19541,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 48040,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "700",
+        "winnerCount": 73226
+    },
+    {
+        "drawTime": "20191218195900",
+        "jackpot": [
+            "$160,000,000"
+        ],
+        "numbers": "14,18,26,39,68|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$160,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$3,147,810"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$35,099"
+                    },
+                    {
+                        "name": "4",
+                        "count": 43,
+                        "prize": "$408"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 109,
+                        "prize": "$167"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2660,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 2505,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 18466,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 44519,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "699",
+        "winnerCount": 68303
+    },
+    {
+        "drawTime": "20191214195900",
+        "jackpot": [
+            "$150,000,000"
+        ],
+        "numbers": "3,6,12,32,64|19",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$150,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$3,010,705"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$33,908"
+                    },
+                    {
+                        "name": "4",
+                        "count": 54,
+                        "prize": "$327"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 132,
+                        "prize": "$139"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3393,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 2460,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 17650,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 40179,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "698",
+        "winnerCount": 63870
+    },
+    {
+        "drawTime": "20191211195900",
+        "jackpot": [
+            "$140,000,000"
+        ],
+        "numbers": "24,29,42,44,63|10",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$140,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$2,872,641"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$32,472"
+                    },
+                    {
+                        "name": "4",
+                        "count": 33,
+                        "prize": "$491"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 124,
+                        "prize": "$136"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2370,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 2226,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 16359,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 40528,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "697",
+        "winnerCount": 61640
+    },
+    {
+        "drawTime": "20191207195900",
+        "jackpot": [
+            "$130,000,000"
+        ],
+        "numbers": "18,42,53,62,66|25",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$130,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$2,745,797"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$32,178"
+                    },
+                    {
+                        "name": "4",
+                        "count": 18,
+                        "prize": "$893"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 80,
+                        "prize": "$208"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2237,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1850,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 14933,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 37426,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "696",
+        "winnerCount": 56545
+    },
+    {
+        "drawTime": "20191204195900",
+        "jackpot": [
+            "$120,000,000"
+        ],
+        "numbers": "8,27,44,51,61|14",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$120,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$2,620,099"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$29,445"
+                    },
+                    {
+                        "name": "4",
+                        "count": 32,
+                        "prize": "$460"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 90,
+                        "prize": "$169"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2132,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1864,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 14159,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 33943,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "695",
+        "winnerCount": 52221
+    },
+    {
+        "drawTime": "20191130195900",
+        "jackpot": [
+            "$110,000,000"
+        ],
+        "numbers": "15,35,42,63,68|18",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$110,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$2,505,078"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$27,166"
+                    },
+                    {
+                        "name": "4",
+                        "count": 31,
+                        "prize": "$438"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 99,
+                        "prize": "$142"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1875,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1603,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 12645,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 31505,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "694",
+        "winnerCount": 47759
+    },
+    {
+        "drawTime": "20191127195900",
+        "jackpot": [
+            "$100,000,000"
+        ],
+        "numbers": "15,26,37,53,55|21",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$100,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$2,398,957"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$30,290"
+                    },
+                    {
+                        "name": "4",
+                        "count": 35,
+                        "prize": "$432"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 84,
+                        "prize": "$187"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2170,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1794,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 13871,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 34949,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "693",
+        "winnerCount": 52904
+    },
+    {
+        "drawTime": "20191123195900",
+        "jackpot": [
+            "$90,000,000"
+        ],
+        "numbers": "28,35,38,61,66|23",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$90,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$2,280,635"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$26,213"
+                    },
+                    {
+                        "name": "4",
+                        "count": 30,
+                        "prize": "$436"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 79,
+                        "prize": "$172"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1768,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1440,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 12172,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 31250,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "692",
+        "winnerCount": 46740
+    },
+    {
+        "drawTime": "20191120195900",
+        "jackpot": [
+            "$80,000,000"
+        ],
+        "numbers": "7,15,39,40,57|12",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$80,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$2,178,239"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$23,105"
+                    },
+                    {
+                        "name": "4",
+                        "count": 19,
+                        "prize": "$608"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 70,
+                        "prize": "$171"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1774,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1630,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 11653,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 27706,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "691",
+        "winnerCount": 42853
+    },
+    {
+        "drawTime": "20191116195900",
+        "jackpot": [
+            "$70,000,000"
+        ],
+        "numbers": "14,22,26,55,63|26",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$70,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$2,087,984"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$24,144"
+                    },
+                    {
+                        "name": "4",
+                        "count": 30,
+                        "prize": "$402"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 49,
+                        "prize": "$256"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1790,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1519,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 11450,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 27599,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "690",
+        "winnerCount": 42438
+    },
+    {
+        "drawTime": "20191113195900",
+        "jackpot": [
+            "$60,000,000"
+        ],
+        "numbers": "23,26,27,28,66|11",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$60,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,993,669"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$10,915"
+                    },
+                    {
+                        "name": "4",
+                        "count": 21,
+                        "prize": "$519"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 56,
+                        "prize": "$202"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1794,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1539,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 11969,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 26832,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "689",
+        "winnerCount": 42213
+    },
+    {
+        "drawTime": "20191109195900",
+        "jackpot": [
+            "$50,000,000"
+        ],
+        "numbers": "14,17,35,38,60|25",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$50,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,908,391"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$11,259"
+                    },
+                    {
+                        "name": "4",
+                        "count": 20,
+                        "prize": "$562"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 51,
+                        "prize": "$229"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1709,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1375,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 10680,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 25427,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "688",
+        "winnerCount": 39264
+    },
+    {
+        "drawTime": "20191106195900",
+        "jackpot": [
+            "$40,000,000"
+        ],
+        "numbers": "15,28,46,62,64|17",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$40,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,820,426"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$10,579"
+                    },
+                    {
+                        "name": "4",
+                        "count": 26,
+                        "prize": "$406"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 74,
+                        "prize": "$148"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1504,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1295,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 9919,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 25361,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "687",
+        "winnerCount": 38181
+    },
+    {
+        "drawTime": "20191102195900",
+        "jackpot": [
+            "$150,000,000"
+        ],
+        "numbers": "3,23,32,37,58|22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 1,
+                        "prize": "$150,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,737,776"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 3,
+                        "prize": "$12,970"
+                    },
+                    {
+                        "name": "4",
+                        "count": 41,
+                        "prize": "$474"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 98,
+                        "prize": "$206"
+                    },
+                    {
+                        "name": "3",
+                        "count": 3276,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 2455,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 18346,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 43804,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "686",
+        "winnerCount": 68024
+    },
+    {
+        "drawTime": "20191030195900",
+        "jackpot": [
+            "$140,000,000"
+        ],
+        "numbers": "19,22,52,56,67|21",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$140,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,585,773"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$33,045"
+                    },
+                    {
+                        "name": "4",
+                        "count": 42,
+                        "prize": "$393"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 99,
+                        "prize": "$173"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2499,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1880,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 15334,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 37871,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "685",
+        "winnerCount": 57726
+    },
+    {
+        "drawTime": "20191026195900",
+        "jackpot": [
+            "$130,000,000"
+        ],
+        "numbers": "3,20,48,54,59|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$130,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,456,688"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$33,728"
+                    },
+                    {
+                        "name": "4",
+                        "count": 37,
+                        "prize": "$462"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 90,
+                        "prize": "$197"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2386,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 2071,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 16846,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 40896,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "684",
+        "winnerCount": 62328
+    },
+    {
+        "drawTime": "20191023195900",
+        "jackpot": [
+            "$120,000,000"
+        ],
+        "numbers": "5,12,50,61,69|23",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$120,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,323,068"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$33,249"
+                    },
+                    {
+                        "name": "4",
+                        "count": 36,
+                        "prize": "$461"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 84,
+                        "prize": "$205"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2432,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 2020,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 16002,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 38410,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "683",
+        "winnerCount": 58984
+    },
+    {
+        "drawTime": "20191019195900",
+        "jackpot": [
+            "$110,000,000"
+        ],
+        "numbers": "14,27,29,59,65|12",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$110,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,193,187"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$33,025"
+                    },
+                    {
+                        "name": "4",
+                        "count": 35,
+                        "prize": "$471"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 111,
+                        "prize": "$154"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2430,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 2115,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 16346,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 40319,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "682",
+        "winnerCount": 61357
+    },
+    {
+        "drawTime": "20191016195900",
+        "jackpot": [
+            "$100,000,000"
+        ],
+        "numbers": "1,5,25,63,67|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$100,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,064,183"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$32,508"
+                    },
+                    {
+                        "name": "4",
+                        "count": 32,
+                        "prize": "$507"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 113,
+                        "prize": "$149"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2570,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 2240,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 16641,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 39631,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "681",
+        "winnerCount": 61228
+    },
+    {
+        "drawTime": "20191012195900",
+        "jackpot": [
+            "$90,000,000"
+        ],
+        "numbers": "12,29,34,53,65|23",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$90,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$937,198"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 3,
+                        "prize": "$26,557"
+                    },
+                    {
+                        "name": "4",
+                        "count": 34,
+                        "prize": "$409"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 75,
+                        "prize": "$192"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2089,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1589,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 12850,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 31657,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "680",
+        "winnerCount": 48297
+    },
+    {
+        "drawTime": "20191009195900",
+        "jackpot": [
+            "$80,000,000"
+        ],
+        "numbers": "5,18,33,43,65|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$80,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$828,534"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$51,854"
+                    },
+                    {
+                        "name": "4",
+                        "count": 30,
+                        "prize": "$432"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 61,
+                        "prize": "$220"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1986,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1601,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 12389,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 29482,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "679",
+        "winnerCount": 45549
+    },
+    {
+        "drawTime": "20191005195900",
+        "jackpot": [
+            "$70,000,000"
+        ],
+        "numbers": "6,14,36,51,54|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$70,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$727,227"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$25,919"
+                    },
+                    {
+                        "name": "4",
+                        "count": 25,
+                        "prize": "$518"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 71,
+                        "prize": "$189"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1902,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1733,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 13087,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 30889,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "678",
+        "winnerCount": 47707
+    },
+    {
+        "drawTime": "20191002195900",
+        "jackpot": [
+            "$60,000,000"
+        ],
+        "numbers": "4,8,10,43,53|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$60,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$625,980"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$67,177"
+                    },
+                    {
+                        "name": "4",
+                        "count": 38,
+                        "prize": "$309"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 100,
+                        "prize": "$122"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2204,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 2118,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 14298,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 31472,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "677",
+        "winnerCount": 50231
+    },
+    {
+        "drawTime": "20190928195900",
+        "jackpot": [
+            "$50,000,000"
+        ],
+        "numbers": "15,23,34,51,55|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$50,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$534,234"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$43,689"
+                    },
+                    {
+                        "name": "4",
+                        "count": 21,
+                        "prize": "$542"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 73,
+                        "prize": "$162"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1656,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1449,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 11311,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 27348,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "676",
+        "winnerCount": 41858
+    },
+    {
+        "drawTime": "20190925195900",
+        "jackpot": [
+            "$40,000,000"
+        ],
+        "numbers": "37,43,44,45,53|25",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$40,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$445,210"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$20,899"
+                    },
+                    {
+                        "name": "4",
+                        "count": 26,
+                        "prize": "$401"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 48,
+                        "prize": "$226"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1565,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1192,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 9479,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 24353,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "675",
+        "winnerCount": 36663
+    },
+    {
+        "drawTime": "20190921195900",
+        "jackpot": [
+            "$80,000,000"
+        ],
+        "numbers": "1,9,22,36,68|22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$80,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$363,572"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$25,341"
+                    },
+                    {
+                        "name": "4",
+                        "count": 30,
+                        "prize": "$422"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 93,
+                        "prize": "$141"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2073,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1722,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 12274,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 27785,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "674",
+        "winnerCount": 43978
+    },
+    {
+        "drawTime": "20190918195900",
+        "jackpot": [
+            "$70,000,000"
+        ],
+        "numbers": "14,19,39,47,51|15",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$70,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$264,584"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 3,
+                        "prize": "$22,577"
+                    },
+                    {
+                        "name": "4",
+                        "count": 30,
+                        "prize": "$378"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 79,
+                        "prize": "$149"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1696,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1447,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 11276,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 26983,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "673",
+        "winnerCount": 41514
+    },
+    {
+        "drawTime": "20190914195900",
+        "jackpot": [
+            "$60,000,000"
+        ],
+        "numbers": "11,27,31,36,67|11",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$60,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$175,885"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$45,027"
+                    },
+                    {
+                        "name": "4",
+                        "count": 30,
+                        "prize": "$391"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 83,
+                        "prize": "$147"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1730,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1716,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 12790,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 28707,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "672",
+        "winnerCount": 45056
+    },
+    {
+        "drawTime": "20190911195900",
+        "jackpot": [
+            "$50,000,000"
+        ],
+        "numbers": "6,17,24,53,57|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$50,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$84,024"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 0,
+                        "prize": "$21,510"
+                    },
+                    {
+                        "name": "4",
+                        "count": 19,
+                        "prize": "$566"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 81,
+                        "prize": "$137"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1834,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1432,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 11413,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 26190,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "671",
+        "winnerCount": 40969
+    },
+    {
+        "drawTime": "20190907195900",
+        "jackpot": [
+            "$40,000,000"
+        ],
+        "numbers": "11,20,41,42,56|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$40,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$1,469,638"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$11,171"
+                    },
+                    {
+                        "name": "4",
+                        "count": 16,
+                        "prize": "$698"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 71,
+                        "prize": "$163"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1655,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1427,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 11496,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 27426,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "670",
+        "winnerCount": 42094
+    },
+    {
+        "drawTime": "20190904195900",
+        "jackpot": [
+            "$80,000,000"
+        ],
+        "numbers": "4,8,30,52,59|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$80,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,382,359"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$23,508"
+                    },
+                    {
+                        "name": "4",
+                        "count": 27,
+                        "prize": "$435"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 70,
+                        "prize": "$174"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1943,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1529,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 11420,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 26465,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "669",
+        "winnerCount": 41455
+    },
+    {
+        "drawTime": "20190831195900",
+        "jackpot": [
+            "$70,000,000"
+        ],
+        "numbers": "14,41,50,56,57|18",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$70,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,290,529"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$24,703"
+                    },
+                    {
+                        "name": "4",
+                        "count": 21,
+                        "prize": "$588"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 64,
+                        "prize": "$200"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1714,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1353,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 11047,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 28886,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "668",
+        "winnerCount": 43086
+    },
+    {
+        "drawTime": "20190828195900",
+        "jackpot": [
+            "$60,000,000"
+        ],
+        "numbers": "9,32,37,41,56|14",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$60,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,194,033"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 3,
+                        "prize": "$7,359"
+                    },
+                    {
+                        "name": "4",
+                        "count": 28,
+                        "prize": "$394"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 78,
+                        "prize": "$147"
+                    },
+                    {
+                        "name": "3",
+                        "count": 1631,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1322,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 10551,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 25426,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "667",
+        "winnerCount": 39039
+    },
+    {
+        "drawTime": "20190824195900",
+        "jackpot": [
+            "$50,000,000"
+        ],
+        "numbers": "5,12,20,21,47|1",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$50,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,107,786"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$11,446"
+                    },
+                    {
+                        "name": "4",
+                        "count": 51,
+                        "prize": "$224"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 67,
+                        "prize": "$177"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2524,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1566,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 11254,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 24872,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "666",
+        "winnerCount": 40336
+    },
+    {
+        "drawTime": "20190821195900",
+        "jackpot": [
+            "$40,000,000"
+        ],
+        "numbers": "12,21,22,29,32|21",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$40,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$1,018,360"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$20,871"
+                    },
+                    {
+                        "name": "4",
+                        "count": 37,
+                        "prize": "$282"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 66,
+                        "prize": "$164"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2060,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1438,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 10271,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 22959,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "665",
+        "winnerCount": 36832
+    },
+    {
+        "drawTime": "20190817195900",
+        "jackpot": [
+            "$149,000,000"
+        ],
+        "numbers": "18,21,24,30,60|20",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$149,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$936,833"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$35,271"
+                    },
+                    {
+                        "name": "4",
+                        "count": 49,
+                        "prize": "$359"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 106,
+                        "prize": "$172"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2949,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 2151,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 16391,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 39776,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "664",
+        "winnerCount": 61423
+    },
+    {
+        "drawTime": "20190814195900",
+        "jackpot": [
+            "$138,000,000"
+        ],
+        "numbers": "10,13,30,51,69|10",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$138,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$799,056"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$16,757"
+                    },
+                    {
+                        "name": "4",
+                        "count": 36,
+                        "prize": "$465"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 129,
+                        "prize": "$134"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2534,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 2272,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 17778,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 40888,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "663",
+        "winnerCount": 63639
+    },
+    {
+        "drawTime": "20190810195900",
+        "jackpot": [
+            "$128,000,000"
+        ],
+        "numbers": "35,41,44,58,59|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$128,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$668,141"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 1,
+                        "prize": "$34,012"
+                    },
+                    {
+                        "name": "4",
+                        "count": 32,
+                        "prize": "$531"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 106,
+                        "prize": "$166"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2288,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 2006,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 15994,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 42852,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "662",
+        "winnerCount": 63279
+    },
+    {
+        "drawTime": "20190807195900",
+        "jackpot": [
+            "$112,000,000"
+        ],
+        "numbers": "8,32,47,53,59|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$112,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$535,281"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$15,789"
+                    },
+                    {
+                        "name": "4",
+                        "count": 36,
+                        "prize": "$438"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 90,
+                        "prize": "$182"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2194,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 1973,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 15735,
+                        "prize": "$5"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 37948,
+                        "prize": "$4"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "661",
+        "winnerCount": 57978
+    },
+    {
+        "drawTime": "20190803195900",
+        "jackpot": [
+            "$102,000,000"
+        ],
+        "numbers": "3,6,45,66,68|13",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Powerball",
+                        "count": 0,
+                        "prize": "$102,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$411,927"
+                    },
+                    {
+                        "name": "4 + Powerball",
+                        "count": 2,
+                        "prize": "$41,630"
+                    },
+                    {
+                        "name": "4",
+                        "count": 39,
+                        "prize": "$413"
+                    },
+                    {
+                        "name": "3 + Powerball",
+                        "count": 114,
+                        "prize": "$146"
+                    },
+                    {
+                        "name": "3",
+                        "count": 2446,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Powerball",
+                        "count": 2237,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Powerball",
+                        "count": 17326,
+                        "prize": "$4"
+                    },
+                    {
+                        "name": "Powerball",
+                        "count": 40249,
+                        "prize": "$3"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Powerball",
+        "lotteryID": "us_ca-powerball",
+        "issue": "660",
+        "winnerCount": 62413
+    }
+]

--- a/crawler/us/ca/history/us_ca-superlotto-plus.json
+++ b/crawler/us/ca/history/us_ca-superlotto-plus.json
@@ -1,0 +1,6786 @@
+[
+    {
+        "drawTime": "20200805195700",
+        "jackpot": [
+            "$11,000,000"
+        ],
+        "numbers": "2,4,5,40,47|16",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$11,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$14,898"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 12,
+                        "prize": "$1,241"
+                    },
+                    {
+                        "name": "4",
+                        "count": 237,
+                        "prize": "$104"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 374,
+                        "prize": "$59"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11538,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5017,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 25006,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 37044,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3479",
+        "winnerCount": 79230
+    },
+    {
+        "drawTime": "20200801195700",
+        "jackpot": [
+            "$10,000,000"
+        ],
+        "numbers": "5,6,8,12,42|23",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$10,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$15,391"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 14,
+                        "prize": "$1,099"
+                    },
+                    {
+                        "name": "4",
+                        "count": 360,
+                        "prize": "$71"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 528,
+                        "prize": "$43"
+                    },
+                    {
+                        "name": "3",
+                        "count": 13603,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6255,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 28323,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 40980,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3478",
+        "winnerCount": 90065
+    },
+    {
+        "drawTime": "20200729195700",
+        "jackpot": [
+            "$9,000,000"
+        ],
+        "numbers": "2,16,20,21,34|20",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$9,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$27,882"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 9,
+                        "prize": "$1,549"
+                    },
+                    {
+                        "name": "4",
+                        "count": 235,
+                        "prize": "$98"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 394,
+                        "prize": "$53"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10068,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5083,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 24423,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 36481,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3477",
+        "winnerCount": 76693
+    },
+    {
+        "drawTime": "20200725195700",
+        "jackpot": [
+            "$8,000,000"
+        ],
+        "numbers": "8,10,12,35,39|26",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$8,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$29,212"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 11,
+                        "prize": "$1,327"
+                    },
+                    {
+                        "name": "4",
+                        "count": 298,
+                        "prize": "$81"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 398,
+                        "prize": "$55"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11343,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5190,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 24159,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 35461,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3476",
+        "winnerCount": 76861
+    },
+    {
+        "drawTime": "20200722195700",
+        "jackpot": [
+            "$7,000,000"
+        ],
+        "numbers": "4,8,30,33,40|17",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$7,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$26,923"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 9,
+                        "prize": "$1,495"
+                    },
+                    {
+                        "name": "4",
+                        "count": 227,
+                        "prize": "$98"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 358,
+                        "prize": "$56"
+                    },
+                    {
+                        "name": "3",
+                        "count": 9691,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5018,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 24240,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 35640,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3475",
+        "winnerCount": 75183
+    },
+    {
+        "drawTime": "20200718195700",
+        "jackpot": [
+            "$24,000,000"
+        ],
+        "numbers": "16,30,37,39,43|14",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 1,
+                        "prize": "$24,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$35,488"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 10,
+                        "prize": "$1,774"
+                    },
+                    {
+                        "name": "4",
+                        "count": 231,
+                        "prize": "$128"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 437,
+                        "prize": "$60"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11237,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5717,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 29589,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 47485,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3474",
+        "winnerCount": 94708
+    },
+    {
+        "drawTime": "20200715195700",
+        "jackpot": [
+            "$23,000,000"
+        ],
+        "numbers": "7,25,34,40,44|26",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$23,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$16,901"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 5,
+                        "prize": "$3,380"
+                    },
+                    {
+                        "name": "4",
+                        "count": 287,
+                        "prize": "$98"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 410,
+                        "prize": "$61"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11175,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5546,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 27734,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 42612,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3473",
+        "winnerCount": 87771
+    },
+    {
+        "drawTime": "20200711195700",
+        "jackpot": [
+            "$22,000,000"
+        ],
+        "numbers": "2,12,16,19,31|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$22,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$35,061"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 17,
+                        "prize": "$1,031"
+                    },
+                    {
+                        "name": "4",
+                        "count": 330,
+                        "prize": "$88"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 574,
+                        "prize": "$45"
+                    },
+                    {
+                        "name": "3",
+                        "count": 13076,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 7070,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 34142,
+                        "prize": "$1"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 50977,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3472",
+        "winnerCount": 106186
+    },
+    {
+        "drawTime": "20200708195700",
+        "jackpot": [
+            "$21,000,000"
+        ],
+        "numbers": "2,25,36,42,47|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$21,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 3,
+                        "prize": "$11,075"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 8,
+                        "prize": "$2,076"
+                    },
+                    {
+                        "name": "4",
+                        "count": 256,
+                        "prize": "$108"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 440,
+                        "prize": "$56"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11086,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5987,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 29524,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 46268,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3471",
+        "winnerCount": 93572
+    },
+    {
+        "drawTime": "20200704195700",
+        "jackpot": [
+            "$20,000,000"
+        ],
+        "numbers": "4,6,10,20,41|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$20,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$17,454"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 14,
+                        "prize": "$1,246"
+                    },
+                    {
+                        "name": "4",
+                        "count": 373,
+                        "prize": "$77"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 538,
+                        "prize": "$48"
+                    },
+                    {
+                        "name": "3",
+                        "count": 14262,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 7327,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 33546,
+                        "prize": "$1"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 50100,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3470",
+        "winnerCount": 106162
+    },
+    {
+        "drawTime": "20200701195700",
+        "jackpot": [
+            "$19,000,000"
+        ],
+        "numbers": "19,22,25,33,42|12",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$19,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$32,695"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 12,
+                        "prize": "$1,362"
+                    },
+                    {
+                        "name": "4",
+                        "count": 275,
+                        "prize": "$99"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 464,
+                        "prize": "$52"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11149,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6227,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 30569,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 47367,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3469",
+        "winnerCount": 96064
+    },
+    {
+        "drawTime": "20200627195700",
+        "jackpot": [
+            "$18,000,000"
+        ],
+        "numbers": "27,32,35,46,47|12",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$18,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$33,605"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 9,
+                        "prize": "$1,866"
+                    },
+                    {
+                        "name": "4",
+                        "count": 266,
+                        "prize": "$105"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 427,
+                        "prize": "$59"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11071,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6189,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 31027,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 49765,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3468",
+        "winnerCount": 98754
+    },
+    {
+        "drawTime": "20200624195700",
+        "jackpot": [
+            "$17,000,000"
+        ],
+        "numbers": "8,11,19,31,42|22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$17,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$32,093"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 17,
+                        "prize": "$943"
+                    },
+                    {
+                        "name": "4",
+                        "count": 253,
+                        "prize": "$105"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 442,
+                        "prize": "$54"
+                    },
+                    {
+                        "name": "3",
+                        "count": 12146,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5891,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 28229,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 41476,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3467",
+        "winnerCount": 88455
+    },
+    {
+        "drawTime": "20200620195700",
+        "jackpot": [
+            "$16,000,000"
+        ],
+        "numbers": "7,13,15,25,30|13",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$16,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 5,
+                        "prize": "$6,667"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 16,
+                        "prize": "$1,041"
+                    },
+                    {
+                        "name": "4",
+                        "count": 512,
+                        "prize": "$54"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 591,
+                        "prize": "$42"
+                    },
+                    {
+                        "name": "3",
+                        "count": 13283,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 7033,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 33938,
+                        "prize": "$1"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 49715,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3466",
+        "winnerCount": 105093
+    },
+    {
+        "drawTime": "20200617195700",
+        "jackpot": [
+            "$15,000,000"
+        ],
+        "numbers": "1,20,30,39,47|21",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$15,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$31,556"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 7,
+                        "prize": "$2,254"
+                    },
+                    {
+                        "name": "4",
+                        "count": 268,
+                        "prize": "$98"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 379,
+                        "prize": "$62"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10748,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5260,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 26101,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 40795,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3465",
+        "winnerCount": 83559
+    },
+    {
+        "drawTime": "20200613195700",
+        "jackpot": [
+            "$14,000,000"
+        ],
+        "numbers": "21,25,30,34,42|18",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$14,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$16,212"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 8,
+                        "prize": "$2,026"
+                    },
+                    {
+                        "name": "4",
+                        "count": 264,
+                        "prize": "$102"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 405,
+                        "prize": "$60"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10624,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5714,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 28399,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 45245,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3464",
+        "winnerCount": 90661
+    },
+    {
+        "drawTime": "20200610195700",
+        "jackpot": [
+            "$13,000,000"
+        ],
+        "numbers": "3,11,20,25,46|21",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$13,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$29,565"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 11,
+                        "prize": "$1,343"
+                    },
+                    {
+                        "name": "4",
+                        "count": 287,
+                        "prize": "$85"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 391,
+                        "prize": "$56"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11052,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5267,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 25106,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 37085,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3463",
+        "winnerCount": 79199
+    },
+    {
+        "drawTime": "20200606195700",
+        "jackpot": [
+            "$12,000,000"
+        ],
+        "numbers": "5,21,22,34,39|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$12,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$30,592"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 6,
+                        "prize": "$2,549"
+                    },
+                    {
+                        "name": "4",
+                        "count": 242,
+                        "prize": "$105"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 456,
+                        "prize": "$50"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10755,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5918,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 29595,
+                        "prize": "$1"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 44408,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3462",
+        "winnerCount": 91380
+    },
+    {
+        "drawTime": "20200603195700",
+        "jackpot": [
+            "$11,000,000"
+        ],
+        "numbers": "7,17,26,36,42|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$11,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$28,003"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 11,
+                        "prize": "$1,272"
+                    },
+                    {
+                        "name": "4",
+                        "count": 253,
+                        "prize": "$92"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 379,
+                        "prize": "$55"
+                    },
+                    {
+                        "name": "3",
+                        "count": 9751,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5172,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 26331,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 39874,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3461",
+        "winnerCount": 81771
+    },
+    {
+        "drawTime": "20200530195700",
+        "jackpot": [
+            "$10,000,000"
+        ],
+        "numbers": "6,13,21,36,38|25",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$10,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$29,534"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 8,
+                        "prize": "$1,845"
+                    },
+                    {
+                        "name": "4",
+                        "count": 282,
+                        "prize": "$87"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 383,
+                        "prize": "$57"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10914,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5014,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 25057,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 38444,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3460",
+        "winnerCount": 80103
+    },
+    {
+        "drawTime": "20200527195700",
+        "jackpot": [
+            "$9,000,000"
+        ],
+        "numbers": "2,5,11,14,44|21",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$9,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$26,363"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 11,
+                        "prize": "$1,198"
+                    },
+                    {
+                        "name": "4",
+                        "count": 259,
+                        "prize": "$84"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 370,
+                        "prize": "$53"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10691,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 4891,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 22551,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 32331,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3459",
+        "winnerCount": 71104
+    },
+    {
+        "drawTime": "20200523195700",
+        "jackpot": [
+            "$8,000,000"
+        ],
+        "numbers": "7,27,35,43,45|15",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$8,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$28,092"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 13,
+                        "prize": "$1,080"
+                    },
+                    {
+                        "name": "4",
+                        "count": 251,
+                        "prize": "$93"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 391,
+                        "prize": "$53"
+                    },
+                    {
+                        "name": "3",
+                        "count": 9621,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5030,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 24365,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 37097,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3458",
+        "winnerCount": 76768
+    },
+    {
+        "drawTime": "20200520195700",
+        "jackpot": [
+            "$7,000,000"
+        ],
+        "numbers": "2,24,29,30,37|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$7,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$25,537"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 8,
+                        "prize": "$1,596"
+                    },
+                    {
+                        "name": "4",
+                        "count": 180,
+                        "prize": "$118"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 323,
+                        "prize": "$59"
+                    },
+                    {
+                        "name": "3",
+                        "count": 8339,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 4774,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 24025,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 37877,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3457",
+        "winnerCount": 75527
+    },
+    {
+        "drawTime": "20200516195700",
+        "jackpot": [
+            "$28,000,000"
+        ],
+        "numbers": "3,9,23,27,35|16",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 1,
+                        "prize": "$28,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 4,
+                        "prize": "$8,476"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 6,
+                        "prize": "$2,825"
+                    },
+                    {
+                        "name": "4",
+                        "count": 354,
+                        "prize": "$79"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 482,
+                        "prize": "$52"
+                    },
+                    {
+                        "name": "3",
+                        "count": 13994,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6134,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 28573,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 42084,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3456",
+        "winnerCount": 91632
+    },
+    {
+        "drawTime": "20200513195700",
+        "jackpot": [
+            "$27,000,000"
+        ],
+        "numbers": "4,10,20,22,23|23",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$27,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$31,624"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 15,
+                        "prize": "$1,054"
+                    },
+                    {
+                        "name": "4",
+                        "count": 294,
+                        "prize": "$89"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 529,
+                        "prize": "$44"
+                    },
+                    {
+                        "name": "3",
+                        "count": 13215,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6283,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 28800,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 41947,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3455",
+        "winnerCount": 91084
+    },
+    {
+        "drawTime": "20200509195700",
+        "jackpot": [
+            "$26,000,000"
+        ],
+        "numbers": "4,19,24,39,45|14",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$26,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$16,342"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 8,
+                        "prize": "$2,042"
+                    },
+                    {
+                        "name": "4",
+                        "count": 280,
+                        "prize": "$97"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 432,
+                        "prize": "$56"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11135,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5551,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 28155,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 42680,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3454",
+        "winnerCount": 88243
+    },
+    {
+        "drawTime": "20200506195700",
+        "jackpot": [
+            "$25,000,000"
+        ],
+        "numbers": "5,8,19,37,39|11",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$25,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$30,448"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 6,
+                        "prize": "$2,537"
+                    },
+                    {
+                        "name": "4",
+                        "count": 262,
+                        "prize": "$96"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 474,
+                        "prize": "$48"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11105,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5959,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 28602,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 43117,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3453",
+        "winnerCount": 89526
+    },
+    {
+        "drawTime": "20200502195700",
+        "jackpot": [
+            "$24,000,000"
+        ],
+        "numbers": "4,7,21,37,43|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$24,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 3,
+                        "prize": "$10,563"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 10,
+                        "prize": "$1,584"
+                    },
+                    {
+                        "name": "4",
+                        "count": 249,
+                        "prize": "$106"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 519,
+                        "prize": "$45"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11172,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 7348,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 32538,
+                        "prize": "$1"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 47838,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3452",
+        "winnerCount": 99677
+    },
+    {
+        "drawTime": "20200429195700",
+        "jackpot": [
+            "$23,000,000"
+        ],
+        "numbers": "2,9,15,34,46|25",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$23,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$28,616"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 4,
+                        "prize": "$3,577"
+                    },
+                    {
+                        "name": "4",
+                        "count": 227,
+                        "prize": "$105"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 372,
+                        "prize": "$57"
+                    },
+                    {
+                        "name": "3",
+                        "count": 9937,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5044,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 24643,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 36873,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3451",
+        "winnerCount": 77100
+    },
+    {
+        "drawTime": "20200425195700",
+        "jackpot": [
+            "$22,000,000"
+        ],
+        "numbers": "15,20,27,38,40|15",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$22,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$29,065"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 10,
+                        "prize": "$1,453"
+                    },
+                    {
+                        "name": "4",
+                        "count": 232,
+                        "prize": "$104"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 381,
+                        "prize": "$57"
+                    },
+                    {
+                        "name": "3",
+                        "count": 9796,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5069,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 25095,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 38254,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3450",
+        "winnerCount": 78838
+    },
+    {
+        "drawTime": "20200422195700",
+        "jackpot": [
+            "$21,000,000"
+        ],
+        "numbers": "1,10,11,15,30|27",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$21,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$13,773"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 15,
+                        "prize": "$918"
+                    },
+                    {
+                        "name": "4",
+                        "count": 322,
+                        "prize": "$71"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 485,
+                        "prize": "$42"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11938,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5608,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 24705,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 35989,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3449",
+        "winnerCount": 79064
+    },
+    {
+        "drawTime": "20200418195700",
+        "jackpot": [
+            "$20,000,000"
+        ],
+        "numbers": "1,18,20,21,26|17",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$20,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$28,677"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 10,
+                        "prize": "$1,433"
+                    },
+                    {
+                        "name": "4",
+                        "count": 244,
+                        "prize": "$97"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 372,
+                        "prize": "$57"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10411,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5164,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 25496,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 38424,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3448",
+        "winnerCount": 80121
+    },
+    {
+        "drawTime": "20200415195700",
+        "jackpot": [
+            "$19,000,000"
+        ],
+        "numbers": "5,8,9,27,37|11",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$19,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$25,736"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 6,
+                        "prize": "$2,144"
+                    },
+                    {
+                        "name": "4",
+                        "count": 245,
+                        "prize": "$87"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 473,
+                        "prize": "$40"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10738,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5525,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 24548,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 35478,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3447",
+        "winnerCount": 77013
+    },
+    {
+        "drawTime": "20200411195700",
+        "jackpot": [
+            "$18,000,000"
+        ],
+        "numbers": "1,4,8,27,29|23",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$18,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$12,883"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 10,
+                        "prize": "$1,288"
+                    },
+                    {
+                        "name": "4",
+                        "count": 320,
+                        "prize": "$67"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 382,
+                        "prize": "$50"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11666,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5108,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 23562,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 34586,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3446",
+        "winnerCount": 75636
+    },
+    {
+        "drawTime": "20200408195700",
+        "jackpot": [
+            "$17,000,000"
+        ],
+        "numbers": "1,12,27,46,47|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$17,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 3,
+                        "prize": "$7,819"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 9,
+                        "prize": "$1,303"
+                    },
+                    {
+                        "name": "4",
+                        "count": 219,
+                        "prize": "$89"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 326,
+                        "prize": "$53"
+                    },
+                    {
+                        "name": "3",
+                        "count": 8439,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 4402,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 21314,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 31679,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3445",
+        "winnerCount": 66391
+    },
+    {
+        "drawTime": "20200404195700",
+        "jackpot": [
+            "$16,000,000"
+        ],
+        "numbers": "5,7,37,39,46|26",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$16,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$12,725"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 9,
+                        "prize": "$1,413"
+                    },
+                    {
+                        "name": "4",
+                        "count": 210,
+                        "prize": "$100"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 295,
+                        "prize": "$64"
+                    },
+                    {
+                        "name": "3",
+                        "count": 8387,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 4111,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 20483,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 31103,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3444",
+        "winnerCount": 64600
+    },
+    {
+        "drawTime": "20200401195700",
+        "jackpot": [
+            "$15,000,000"
+        ],
+        "numbers": "4,8,22,29,44|18",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$15,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$24,289"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 7,
+                        "prize": "$1,734"
+                    },
+                    {
+                        "name": "4",
+                        "count": 235,
+                        "prize": "$86"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 375,
+                        "prize": "$48"
+                    },
+                    {
+                        "name": "3",
+                        "count": 9994,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 4674,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 22104,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 32475,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3443",
+        "winnerCount": 69865
+    },
+    {
+        "drawTime": "20200328195700",
+        "jackpot": [
+            "$14,000,000"
+        ],
+        "numbers": "9,18,26,29,30|17",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$14,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$25,410"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 12,
+                        "prize": "$1,058"
+                    },
+                    {
+                        "name": "4",
+                        "count": 247,
+                        "prize": "$85"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 363,
+                        "prize": "$52"
+                    },
+                    {
+                        "name": "3",
+                        "count": 9649,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 4556,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 22401,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 34143,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3442",
+        "winnerCount": 71371
+    },
+    {
+        "drawTime": "20200325195700",
+        "jackpot": [
+            "$13,000,000"
+        ],
+        "numbers": "18,22,24,28,44|26",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$13,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$12,113"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 6,
+                        "prize": "$2,018"
+                    },
+                    {
+                        "name": "4",
+                        "count": 219,
+                        "prize": "$92"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 290,
+                        "prize": "$62"
+                    },
+                    {
+                        "name": "3",
+                        "count": 8397,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 3897,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 19430,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 30202,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3441",
+        "winnerCount": 62443
+    },
+    {
+        "drawTime": "20200321195700",
+        "jackpot": [
+            "$12,000,000"
+        ],
+        "numbers": "8,9,22,32,39|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$12,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$25,896"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 9,
+                        "prize": "$1,438"
+                    },
+                    {
+                        "name": "4",
+                        "count": 217,
+                        "prize": "$99"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 395,
+                        "prize": "$49"
+                    },
+                    {
+                        "name": "3",
+                        "count": 9587,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5335,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 24395,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 36011,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3440",
+        "winnerCount": 75950
+    },
+    {
+        "drawTime": "20200318195700",
+        "jackpot": [
+            "$11,000,000"
+        ],
+        "numbers": "2,14,17,32,47|24",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$11,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$26,740"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 12,
+                        "prize": "$1,114"
+                    },
+                    {
+                        "name": "4",
+                        "count": 233,
+                        "prize": "$95"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 330,
+                        "prize": "$60"
+                    },
+                    {
+                        "name": "3",
+                        "count": 9402,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 4808,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 23096,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 34909,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3439",
+        "winnerCount": 72791
+    },
+    {
+        "drawTime": "20200314195700",
+        "jackpot": [
+            "$10,000,000"
+        ],
+        "numbers": "4,16,19,25,28|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$10,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$15,256"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 18,
+                        "prize": "$847"
+                    },
+                    {
+                        "name": "4",
+                        "count": 297,
+                        "prize": "$85"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 457,
+                        "prize": "$50"
+                    },
+                    {
+                        "name": "3",
+                        "count": 12051,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5853,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 27615,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 40203,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3438",
+        "winnerCount": 86496
+    },
+    {
+        "drawTime": "20200311195700",
+        "jackpot": [
+            "$9,000,000"
+        ],
+        "numbers": "5,10,20,43,44|10",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$9,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$14,673"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 10,
+                        "prize": "$1,467"
+                    },
+                    {
+                        "name": "4",
+                        "count": 250,
+                        "prize": "$97"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 427,
+                        "prize": "$51"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10402,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5896,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 28767,
+                        "prize": "$1"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 43034,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3437",
+        "winnerCount": 88788
+    },
+    {
+        "drawTime": "20200307195700",
+        "jackpot": [
+            "$8,000,000"
+        ],
+        "numbers": "9,19,20,21,33|16",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$8,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$31,139"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 11,
+                        "prize": "$1,415"
+                    },
+                    {
+                        "name": "4",
+                        "count": 325,
+                        "prize": "$79"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 371,
+                        "prize": "$62"
+                    },
+                    {
+                        "name": "3",
+                        "count": 12003,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5255,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 25377,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 38426,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3436",
+        "winnerCount": 81769
+    },
+    {
+        "drawTime": "20200304195700",
+        "jackpot": [
+            "$7,000,000"
+        ],
+        "numbers": "1,4,26,38,46|11",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$7,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 3,
+                        "prize": "$9,668"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 8,
+                        "prize": "$1,812"
+                    },
+                    {
+                        "name": "4",
+                        "count": 244,
+                        "prize": "$99"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 377,
+                        "prize": "$57"
+                    },
+                    {
+                        "name": "3",
+                        "count": 9667,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5551,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 27338,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 42127,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3435",
+        "winnerCount": 85315
+    },
+    {
+        "drawTime": "20200229195700",
+        "jackpot": [
+            "$12,000,000"
+        ],
+        "numbers": "5,20,22,24,32|15",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 1,
+                        "prize": "$12,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$34,297"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 12,
+                        "prize": "$1,429"
+                    },
+                    {
+                        "name": "4",
+                        "count": 298,
+                        "prize": "$95"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 537,
+                        "prize": "$47"
+                    },
+                    {
+                        "name": "3",
+                        "count": 12901,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6180,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 30206,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 44850,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3434",
+        "winnerCount": 94985
+    },
+    {
+        "drawTime": "20200226195700",
+        "jackpot": [
+            "$11,000,000"
+        ],
+        "numbers": "4,11,24,28,41|25",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$11,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$31,702"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 7,
+                        "prize": "$2,264"
+                    },
+                    {
+                        "name": "4",
+                        "count": 317,
+                        "prize": "$83"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 408,
+                        "prize": "$58"
+                    },
+                    {
+                        "name": "3",
+                        "count": 12340,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5605,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 26942,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 40925,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3433",
+        "winnerCount": 86545
+    },
+    {
+        "drawTime": "20200222195700",
+        "jackpot": [
+            "$10,000,000"
+        ],
+        "numbers": "17,32,36,37,44|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$10,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$33,369"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 11,
+                        "prize": "$1,516"
+                    },
+                    {
+                        "name": "4",
+                        "count": 242,
+                        "prize": "$114"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 423,
+                        "prize": "$59"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10594,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5608,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 29174,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 49423,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3432",
+        "winnerCount": 95476
+    },
+    {
+        "drawTime": "20200219195700",
+        "jackpot": [
+            "$9,000,000"
+        ],
+        "numbers": "2,7,8,41,46|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$9,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$30,020"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 10,
+                        "prize": "$1,501"
+                    },
+                    {
+                        "name": "4",
+                        "count": 224,
+                        "prize": "$111"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 408,
+                        "prize": "$55"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10886,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5830,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 28840,
+                        "prize": "$1"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 42060,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3431",
+        "winnerCount": 88259
+    },
+    {
+        "drawTime": "20200215195700",
+        "jackpot": [
+            "$8,000,000"
+        ],
+        "numbers": "1,6,29,34,37|18",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$8,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$15,778"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 10,
+                        "prize": "$1,577"
+                    },
+                    {
+                        "name": "4",
+                        "count": 238,
+                        "prize": "$110"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 405,
+                        "prize": "$58"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10523,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5722,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 28679,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 44226,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3430",
+        "winnerCount": 89805
+    },
+    {
+        "drawTime": "20200212195700",
+        "jackpot": [
+            "$7,000,000"
+        ],
+        "numbers": "11,13,20,24,35|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$7,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$28,708"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 6,
+                        "prize": "$2,392"
+                    },
+                    {
+                        "name": "4",
+                        "count": 243,
+                        "prize": "$98"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 393,
+                        "prize": "$54"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10263,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5226,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 26233,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 38839,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3429",
+        "winnerCount": 81203
+    },
+    {
+        "drawTime": "20200208195700",
+        "jackpot": [
+            "$12,000,000"
+        ],
+        "numbers": "6,24,26,28,32|24",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 1,
+                        "prize": "$12,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$34,217"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 9,
+                        "prize": "$1,900"
+                    },
+                    {
+                        "name": "4",
+                        "count": 275,
+                        "prize": "$103"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 459,
+                        "prize": "$55"
+                    },
+                    {
+                        "name": "3",
+                        "count": 12317,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6191,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 30054,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 44666,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3428",
+        "winnerCount": 93972
+    },
+    {
+        "drawTime": "20200205195700",
+        "jackpot": [
+            "$11,000,000"
+        ],
+        "numbers": "7,12,18,37,42|17",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$11,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$31,591"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 4,
+                        "prize": "$3,948"
+                    },
+                    {
+                        "name": "4",
+                        "count": 270,
+                        "prize": "$97"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 397,
+                        "prize": "$59"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11026,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5621,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 28000,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 42268,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3427",
+        "winnerCount": 87587
+    },
+    {
+        "drawTime": "20200201195700",
+        "jackpot": [
+            "$10,000,000"
+        ],
+        "numbers": "1,14,18,25,35|21",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$10,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 3,
+                        "prize": "$11,205"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 6,
+                        "prize": "$2,801"
+                    },
+                    {
+                        "name": "4",
+                        "count": 266,
+                        "prize": "$105"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 480,
+                        "prize": "$52"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11483,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5661,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 28269,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 43252,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3426",
+        "winnerCount": 89420
+    },
+    {
+        "drawTime": "20200129195700",
+        "jackpot": [
+            "$9,000,000"
+        ],
+        "numbers": "22,26,28,29,36|4",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$9,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$31,549"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 14,
+                        "prize": "$1,126"
+                    },
+                    {
+                        "name": "4",
+                        "count": 242,
+                        "prize": "$108"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 411,
+                        "prize": "$57"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10629,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5687,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 28643,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 43498,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3425",
+        "winnerCount": 89125
+    },
+    {
+        "drawTime": "20200125195700",
+        "jackpot": [
+            "$8,000,000"
+        ],
+        "numbers": "3,4,10,26,30|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$8,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$34,261"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 17,
+                        "prize": "$1,007"
+                    },
+                    {
+                        "name": "4",
+                        "count": 400,
+                        "prize": "$71"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 522,
+                        "prize": "$49"
+                    },
+                    {
+                        "name": "3",
+                        "count": 14362,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6972,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 30378,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 44236,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3424",
+        "winnerCount": 96887
+    },
+    {
+        "drawTime": "20200122195700",
+        "jackpot": [
+            "$7,000,000"
+        ],
+        "numbers": "1,14,29,39,41|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$7,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$29,332"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 5,
+                        "prize": "$2,933"
+                    },
+                    {
+                        "name": "4",
+                        "count": 270,
+                        "prize": "$90"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 379,
+                        "prize": "$58"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10009,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5357,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 27504,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 43739,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3423",
+        "winnerCount": 87264
+    },
+    {
+        "drawTime": "20200118195700",
+        "jackpot": [
+            "$14,000,000"
+        ],
+        "numbers": "6,7,20,27,42|12",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 1,
+                        "prize": "$14,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$17,513"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 11,
+                        "prize": "$1,592"
+                    },
+                    {
+                        "name": "4",
+                        "count": 298,
+                        "prize": "$97"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 528,
+                        "prize": "$49"
+                    },
+                    {
+                        "name": "3",
+                        "count": 13208,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 7183,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 34674,
+                        "prize": "$1"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 49165,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3422",
+        "winnerCount": 105070
+    },
+    {
+        "drawTime": "20200115195700",
+        "jackpot": [
+            "$13,000,000"
+        ],
+        "numbers": "7,21,28,42,44|22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$13,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$32,820"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 13,
+                        "prize": "$1,262"
+                    },
+                    {
+                        "name": "4",
+                        "count": 315,
+                        "prize": "$86"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 484,
+                        "prize": "$50"
+                    },
+                    {
+                        "name": "3",
+                        "count": 12523,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5904,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 28547,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 42616,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3421",
+        "winnerCount": 90403
+    },
+    {
+        "drawTime": "20200111195700",
+        "jackpot": [
+            "$12,000,000"
+        ],
+        "numbers": "4,9,13,18,34|22",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$12,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$33,514"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 9,
+                        "prize": "$1,861"
+                    },
+                    {
+                        "name": "4",
+                        "count": 323,
+                        "prize": "$86"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 496,
+                        "prize": "$50"
+                    },
+                    {
+                        "name": "3",
+                        "count": 12750,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6330,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 29496,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 43664,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3420",
+        "winnerCount": 93069
+    },
+    {
+        "drawTime": "20200108195700",
+        "jackpot": [
+            "$11,000,000"
+        ],
+        "numbers": "1,16,34,35,47|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$11,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$31,799"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 11,
+                        "prize": "$1,445"
+                    },
+                    {
+                        "name": "4",
+                        "count": 218,
+                        "prize": "$121"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 390,
+                        "prize": "$61"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10543,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5182,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 26593,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 41990,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3419",
+        "winnerCount": 84927
+    },
+    {
+        "drawTime": "20200104195700",
+        "jackpot": [
+            "$10,000,000"
+        ],
+        "numbers": "25,29,31,33,42|19",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$10,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$33,208"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 7,
+                        "prize": "$2,372"
+                    },
+                    {
+                        "name": "4",
+                        "count": 230,
+                        "prize": "$120"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 411,
+                        "prize": "$60"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10952,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5790,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 29112,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 45396,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3418",
+        "winnerCount": 91898
+    },
+    {
+        "drawTime": "20200101195700",
+        "jackpot": [
+            "$9,000,000"
+        ],
+        "numbers": "4,9,17,35,40|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$9,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$33,501"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 17,
+                        "prize": "$985"
+                    },
+                    {
+                        "name": "4",
+                        "count": 271,
+                        "prize": "$103"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 500,
+                        "prize": "$50"
+                    },
+                    {
+                        "name": "3",
+                        "count": 12313,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6781,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 32133,
+                        "prize": "$1"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 48082,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3417",
+        "winnerCount": 100098
+    },
+    {
+        "drawTime": "20191228195700",
+        "jackpot": [
+            "$8,000,000"
+        ],
+        "numbers": "16,21,33,36,39|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$8,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$30,815"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 8,
+                        "prize": "$1,925"
+                    },
+                    {
+                        "name": "4",
+                        "count": 240,
+                        "prize": "$106"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 366,
+                        "prize": "$63"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10592,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5173,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 25486,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 40842,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3416",
+        "winnerCount": 82707
+    },
+    {
+        "drawTime": "20191225195700",
+        "jackpot": [
+            "$7,000,000"
+        ],
+        "numbers": "20,21,32,36,37|14",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$7,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$32,414"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 9,
+                        "prize": "$1,800"
+                    },
+                    {
+                        "name": "4",
+                        "count": 246,
+                        "prize": "$109"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 400,
+                        "prize": "$60"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10304,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5293,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 27423,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 43166,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3415",
+        "winnerCount": 86841
+    },
+    {
+        "drawTime": "20191221195700",
+        "jackpot": [
+            "$13,000,000"
+        ],
+        "numbers": "10,15,27,37,40|25",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 1,
+                        "prize": "$13,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$34,755"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 5,
+                        "prize": "$3,475"
+                    },
+                    {
+                        "name": "4",
+                        "count": 297,
+                        "prize": "$97"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 408,
+                        "prize": "$63"
+                    },
+                    {
+                        "name": "3",
+                        "count": 12062,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6039,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 29681,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 45798,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3414",
+        "winnerCount": 94292
+    },
+    {
+        "drawTime": "20191218195700",
+        "jackpot": [
+            "$12,000,000"
+        ],
+        "numbers": "1,4,11,23,36|10",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$12,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$32,140"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 12,
+                        "prize": "$1,339"
+                    },
+                    {
+                        "name": "4",
+                        "count": 329,
+                        "prize": "$81"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 566,
+                        "prize": "$42"
+                    },
+                    {
+                        "name": "3",
+                        "count": 12654,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6946,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 32883,
+                        "prize": "$1"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 47608,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3413",
+        "winnerCount": 100999
+    },
+    {
+        "drawTime": "20191214195700",
+        "jackpot": [
+            "$11,000,000"
+        ],
+        "numbers": "8,9,22,42,43|20",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$11,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$33,620"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 11,
+                        "prize": "$1,528"
+                    },
+                    {
+                        "name": "4",
+                        "count": 250,
+                        "prize": "$112"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 437,
+                        "prize": "$57"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11888,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5865,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 28630,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 43803,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3412",
+        "winnerCount": 90885
+    },
+    {
+        "drawTime": "20191211195700",
+        "jackpot": [
+            "$10,000,000"
+        ],
+        "numbers": "2,3,6,9,11|26",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$10,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 5,
+                        "prize": "$6,225"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 31,
+                        "prize": "$502"
+                    },
+                    {
+                        "name": "4",
+                        "count": 772,
+                        "prize": "$33"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 597,
+                        "prize": "$39"
+                    },
+                    {
+                        "name": "3",
+                        "count": 17905,
+                        "prize": "$6"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6308,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 25853,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 37080,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3411",
+        "winnerCount": 88551
+    },
+    {
+        "drawTime": "20191207195700",
+        "jackpot": [
+            "$9,000,000"
+        ],
+        "numbers": "4,8,31,44,45|20",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$9,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$15,692"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 7,
+                        "prize": "$2,241"
+                    },
+                    {
+                        "name": "4",
+                        "count": 254,
+                        "prize": "$102"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 381,
+                        "prize": "$61"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11017,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5601,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 26827,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 41391,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3410",
+        "winnerCount": 85480
+    },
+    {
+        "drawTime": "20191204195700",
+        "jackpot": [
+            "$8,000,000"
+        ],
+        "numbers": "1,14,21,28,39|13",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$8,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$28,720"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 9,
+                        "prize": "$1,595"
+                    },
+                    {
+                        "name": "4",
+                        "count": 291,
+                        "prize": "$82"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 493,
+                        "prize": "$43"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10873,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6042,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 29360,
+                        "prize": "$1"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 44234,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3409",
+        "winnerCount": 91303
+    },
+    {
+        "drawTime": "20191130195700",
+        "jackpot": [
+            "$7,000,000"
+        ],
+        "numbers": "7,32,36,40,47|24",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$7,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$26,941"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 5,
+                        "prize": "$2,694"
+                    },
+                    {
+                        "name": "4",
+                        "count": 198,
+                        "prize": "$113"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 340,
+                        "prize": "$59"
+                    },
+                    {
+                        "name": "3",
+                        "count": 8762,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 4538,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 22489,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 35124,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3408",
+        "winnerCount": 71457
+    },
+    {
+        "drawTime": "20191127195700",
+        "jackpot": [
+            "$10,000,000"
+        ],
+        "numbers": "14,19,24,36,47|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 1,
+                        "prize": "$10,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$31,681"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 9,
+                        "prize": "$1,760"
+                    },
+                    {
+                        "name": "4",
+                        "count": 254,
+                        "prize": "$103"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 428,
+                        "prize": "$55"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10706,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5598,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 27799,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 42707,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3407",
+        "winnerCount": 87502
+    },
+    {
+        "drawTime": "20191123195700",
+        "jackpot": [
+            "$9,000,000"
+        ],
+        "numbers": "9,15,27,41,43|17",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$9,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$15,685"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 5,
+                        "prize": "$3,137"
+                    },
+                    {
+                        "name": "4",
+                        "count": 264,
+                        "prize": "$99"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 448,
+                        "prize": "$52"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11100,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5531,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 27788,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 42262,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3406",
+        "winnerCount": 87400
+    },
+    {
+        "drawTime": "20191120195700",
+        "jackpot": [
+            "$8,000,000"
+        ],
+        "numbers": "1,7,9,14,25|16",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$8,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$14,221"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 14,
+                        "prize": "$1,015"
+                    },
+                    {
+                        "name": "4",
+                        "count": 364,
+                        "prize": "$65"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 448,
+                        "prize": "$47"
+                    },
+                    {
+                        "name": "3",
+                        "count": 12966,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5060,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 23336,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 34588,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3405",
+        "winnerCount": 76778
+    },
+    {
+        "drawTime": "20191116195700",
+        "jackpot": [
+            "$7,000,000"
+        ],
+        "numbers": "10,22,40,41,43|2",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$7,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$15,104"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 8,
+                        "prize": "$1,888"
+                    },
+                    {
+                        "name": "4",
+                        "count": 208,
+                        "prize": "$121"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 396,
+                        "prize": "$57"
+                    },
+                    {
+                        "name": "3",
+                        "count": 9731,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5081,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 25491,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 39600,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3404",
+        "winnerCount": 80517
+    },
+    {
+        "drawTime": "20191113195700",
+        "jackpot": [
+            "$10,000,000"
+        ],
+        "numbers": "9,12,23,27,43|12",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 1,
+                        "prize": "$10,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 3,
+                        "prize": "$10,104"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 10,
+                        "prize": "$1,515"
+                    },
+                    {
+                        "name": "4",
+                        "count": 293,
+                        "prize": "$86"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 513,
+                        "prize": "$44"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11561,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6418,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 29670,
+                        "prize": "$1"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 42910,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3403",
+        "winnerCount": 91379
+    },
+    {
+        "drawTime": "20191109195700",
+        "jackpot": [
+            "$9,000,000"
+        ],
+        "numbers": "7,12,26,41,44|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$9,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$31,292"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 9,
+                        "prize": "$1,738"
+                    },
+                    {
+                        "name": "4",
+                        "count": 248,
+                        "prize": "$105"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 451,
+                        "prize": "$52"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10846,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6088,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 29515,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 44304,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3402",
+        "winnerCount": 91462
+    },
+    {
+        "drawTime": "20191106195700",
+        "jackpot": [
+            "$8,000,000"
+        ],
+        "numbers": "3,12,30,36,41|24",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$8,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$14,523"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 17,
+                        "prize": "$854"
+                    },
+                    {
+                        "name": "4",
+                        "count": 235,
+                        "prize": "$103"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 358,
+                        "prize": "$60"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10208,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5006,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 24601,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 37560,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3401",
+        "winnerCount": 77987
+    },
+    {
+        "drawTime": "20191102195700",
+        "jackpot": [
+            "$7,000,000"
+        ],
+        "numbers": "1,9,27,32,45|25",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$7,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$30,528"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 10,
+                        "prize": "$1,526"
+                    },
+                    {
+                        "name": "4",
+                        "count": 254,
+                        "prize": "$100"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 398,
+                        "prize": "$57"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11163,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5133,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 26194,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 39155,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3400",
+        "winnerCount": 82307
+    },
+    {
+        "drawTime": "20191030195700",
+        "jackpot": [
+            "$23,000,000"
+        ],
+        "numbers": "27,34,35,36,40|13",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 1,
+                        "prize": "$23,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$33,851"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 12,
+                        "prize": "$1,410"
+                    },
+                    {
+                        "name": "4",
+                        "count": 266,
+                        "prize": "$106"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 492,
+                        "prize": "$51"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10797,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6396,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 32379,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 53433,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3399",
+        "winnerCount": 103776
+    },
+    {
+        "drawTime": "20191026195700",
+        "jackpot": [
+            "$22,000,000"
+        ],
+        "numbers": "8,11,16,19,23|8",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$22,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$18,046"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 20,
+                        "prize": "$902"
+                    },
+                    {
+                        "name": "4",
+                        "count": 370,
+                        "prize": "$81"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 650,
+                        "prize": "$41"
+                    },
+                    {
+                        "name": "3",
+                        "count": 15464,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 7997,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 35628,
+                        "prize": "$1"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 50142,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3398",
+        "winnerCount": 110273
+    },
+    {
+        "drawTime": "20191023195700",
+        "jackpot": [
+            "$21,000,000"
+        ],
+        "numbers": "11,16,19,22,28|13",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$21,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$17,300"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 11,
+                        "prize": "$1,572"
+                    },
+                    {
+                        "name": "4",
+                        "count": 335,
+                        "prize": "$86"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 600,
+                        "prize": "$43"
+                    },
+                    {
+                        "name": "3",
+                        "count": 13469,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 7650,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 35475,
+                        "prize": "$1"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 51047,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3397",
+        "winnerCount": 108589
+    },
+    {
+        "drawTime": "20191019195700",
+        "jackpot": [
+            "$20,000,000"
+        ],
+        "numbers": "8,17,32,34,45|24",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$20,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 3,
+                        "prize": "$12,058"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 11,
+                        "prize": "$1,644"
+                    },
+                    {
+                        "name": "4",
+                        "count": 287,
+                        "prize": "$105"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 454,
+                        "prize": "$59"
+                    },
+                    {
+                        "name": "3",
+                        "count": 12763,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6459,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 30961,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 47231,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3396",
+        "winnerCount": 98169
+    },
+    {
+        "drawTime": "20191016195700",
+        "jackpot": [
+            "$19,000,000"
+        ],
+        "numbers": "7,18,28,41,44|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$19,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$33,970"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 6,
+                        "prize": "$2,830"
+                    },
+                    {
+                        "name": "4",
+                        "count": 286,
+                        "prize": "$98"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 447,
+                        "prize": "$56"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11675,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6346,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 31669,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 47963,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3395",
+        "winnerCount": 98392
+    },
+    {
+        "drawTime": "20191012195700",
+        "jackpot": [
+            "$18,000,000"
+        ],
+        "numbers": "2,8,11,26,33|14",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$18,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$35,328"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 14,
+                        "prize": "$1,261"
+                    },
+                    {
+                        "name": "4",
+                        "count": 375,
+                        "prize": "$78"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 502,
+                        "prize": "$52"
+                    },
+                    {
+                        "name": "3",
+                        "count": 14879,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6678,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 30628,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 44843,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3394",
+        "winnerCount": 97919
+    },
+    {
+        "drawTime": "20191009195700",
+        "jackpot": [
+            "$17,000,000"
+        ],
+        "numbers": "7,9,14,18,38|12",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$17,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$33,833"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 7,
+                        "prize": "$2,416"
+                    },
+                    {
+                        "name": "4",
+                        "count": 266,
+                        "prize": "$105"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 473,
+                        "prize": "$53"
+                    },
+                    {
+                        "name": "3",
+                        "count": 13004,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6788,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 32482,
+                        "prize": "$1"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 47366,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3393",
+        "winnerCount": 100387
+    },
+    {
+        "drawTime": "20191005195700",
+        "jackpot": [
+            "$16,000,000"
+        ],
+        "numbers": "8,27,33,42,47|12",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$16,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 3,
+                        "prize": "$11,947"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 8,
+                        "prize": "$2,240"
+                    },
+                    {
+                        "name": "4",
+                        "count": 350,
+                        "prize": "$85"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 510,
+                        "prize": "$52"
+                    },
+                    {
+                        "name": "3",
+                        "count": 12722,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6870,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 33898,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 50482,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3392",
+        "winnerCount": 104843
+    },
+    {
+        "drawTime": "20191002195700",
+        "jackpot": [
+            "$15,000,000"
+        ],
+        "numbers": "27,29,34,35,45|15",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$15,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$16,822"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 10,
+                        "prize": "$1,682"
+                    },
+                    {
+                        "name": "4",
+                        "count": 267,
+                        "prize": "$105"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 427,
+                        "prize": "$59"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11129,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5743,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 28833,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 45301,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3391",
+        "winnerCount": 91712
+    },
+    {
+        "drawTime": "20190928195700",
+        "jackpot": [
+            "$14,000,000"
+        ],
+        "numbers": "5,13,33,38,39|16",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$14,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$34,569"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 9,
+                        "prize": "$1,920"
+                    },
+                    {
+                        "name": "4",
+                        "count": 255,
+                        "prize": "$112"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 421,
+                        "prize": "$61"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11607,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5638,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 28273,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 43587,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3390",
+        "winnerCount": 89791
+    },
+    {
+        "drawTime": "20190925195700",
+        "jackpot": [
+            "$13,000,000"
+        ],
+        "numbers": "3,7,11,13,26|12",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$13,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 9,
+                        "prize": "$3,604"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 17,
+                        "prize": "$954"
+                    },
+                    {
+                        "name": "4",
+                        "count": 571,
+                        "prize": "$47"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 609,
+                        "prize": "$39"
+                    },
+                    {
+                        "name": "3",
+                        "count": 16486,
+                        "prize": "$7"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6989,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 30412,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 44608,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3389",
+        "winnerCount": 99701
+    },
+    {
+        "drawTime": "20190921195700",
+        "jackpot": [
+            "$12,000,000"
+        ],
+        "numbers": "1,31,34,37,39|12",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$12,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$17,236"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 18,
+                        "prize": "$957"
+                    },
+                    {
+                        "name": "4",
+                        "count": 284,
+                        "prize": "$101"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 409,
+                        "prize": "$63"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10735,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5956,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 31514,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 51283,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3388",
+        "winnerCount": 100201
+    },
+    {
+        "drawTime": "20190918195700",
+        "jackpot": [
+            "$11,000,000"
+        ],
+        "numbers": "5,7,22,23,27|27",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$11,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$32,036"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 13,
+                        "prize": "$1,232"
+                    },
+                    {
+                        "name": "4",
+                        "count": 373,
+                        "prize": "$71"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 551,
+                        "prize": "$43"
+                    },
+                    {
+                        "name": "3",
+                        "count": 13569,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6747,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 29182,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 41499,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3387",
+        "winnerCount": 91934
+    },
+    {
+        "drawTime": "20190914195700",
+        "jackpot": [
+            "$10,000,000"
+        ],
+        "numbers": "4,10,18,27,30|7",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$10,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 3,
+                        "prize": "$11,346"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 18,
+                        "prize": "$945"
+                    },
+                    {
+                        "name": "4",
+                        "count": 326,
+                        "prize": "$87"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 599,
+                        "prize": "$42"
+                    },
+                    {
+                        "name": "3",
+                        "count": 13575,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 7662,
+                        "prize": "$8"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 35682,
+                        "prize": "$1"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 52398,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3386",
+        "winnerCount": 110263
+    },
+    {
+        "drawTime": "20190911195700",
+        "jackpot": [
+            "$9,000,000"
+        ],
+        "numbers": "4,6,15,24,46|6",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$9,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 2,
+                        "prize": "$15,473"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 12,
+                        "prize": "$1,289"
+                    },
+                    {
+                        "name": "4",
+                        "count": 304,
+                        "prize": "$84"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 563,
+                        "prize": "$41"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11912,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6036,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 27919,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 40469,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3385",
+        "winnerCount": 87217
+    },
+    {
+        "drawTime": "20190907195700",
+        "jackpot": [
+            "$8,000,000"
+        ],
+        "numbers": "8,18,20,23,43|5",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$8,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 1,
+                        "prize": "$31,825"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 11,
+                        "prize": "$1,446"
+                    },
+                    {
+                        "name": "4",
+                        "count": 281,
+                        "prize": "$94"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 486,
+                        "prize": "$49"
+                    },
+                    {
+                        "name": "3",
+                        "count": 11083,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6181,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 30162,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 44735,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3384",
+        "winnerCount": 92940
+    },
+    {
+        "drawTime": "20190904195700",
+        "jackpot": [
+            "$7,000,000"
+        ],
+        "numbers": "16,22,24,43,45|16",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$7,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$29,234"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 8,
+                        "prize": "$1,827"
+                    },
+                    {
+                        "name": "4",
+                        "count": 188,
+                        "prize": "$129"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 334,
+                        "prize": "$65"
+                    },
+                    {
+                        "name": "3",
+                        "count": 9171,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 4701,
+                        "prize": "$12"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 23610,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 36327,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3383",
+        "winnerCount": 74339
+    },
+    {
+        "drawTime": "20190831195700",
+        "jackpot": [
+            "$9,000,000"
+        ],
+        "numbers": "5,8,13,24,39|23",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 1,
+                        "prize": "$9,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$32,854"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 15,
+                        "prize": "$1,095"
+                    },
+                    {
+                        "name": "4",
+                        "count": 321,
+                        "prize": "$85"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 473,
+                        "prize": "$52"
+                    },
+                    {
+                        "name": "3",
+                        "count": 12483,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 6221,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 29940,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 44290,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3382",
+        "winnerCount": 93744
+    },
+    {
+        "drawTime": "20190828195700",
+        "jackpot": [
+            "$8,000,000"
+        ],
+        "numbers": "14,16,21,31,39|3",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$8,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$29,921"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 9,
+                        "prize": "$1,662"
+                    },
+                    {
+                        "name": "4",
+                        "count": 232,
+                        "prize": "$107"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 400,
+                        "prize": "$56"
+                    },
+                    {
+                        "name": "3",
+                        "count": 10156,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5417,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 27432,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 43212,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3381",
+        "winnerCount": 86858
+    },
+    {
+        "drawTime": "20190824195700",
+        "jackpot": [
+            "$7,000,000"
+        ],
+        "numbers": "4,6,14,24,45|21",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$7,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$31,287"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 5,
+                        "prize": "$3,128"
+                    },
+                    {
+                        "name": "4",
+                        "count": 272,
+                        "prize": "$95"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 425,
+                        "prize": "$55"
+                    },
+                    {
+                        "name": "3",
+                        "count": 12294,
+                        "prize": "$9"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 5533,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 26184,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 40021,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3380",
+        "winnerCount": 84734
+    },
+    {
+        "drawTime": "20190821195700",
+        "jackpot": [
+            "$72,000,000"
+        ],
+        "numbers": "19,25,28,34,39|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 1,
+                        "prize": "$72,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 3,
+                        "prize": "$16,638"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 11,
+                        "prize": "$2,268"
+                    },
+                    {
+                        "name": "4",
+                        "count": 355,
+                        "prize": "$117"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 677,
+                        "prize": "$55"
+                    },
+                    {
+                        "name": "3",
+                        "count": 16698,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 9391,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 46330,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 72413,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3379",
+        "winnerCount": 145879
+    },
+    {
+        "drawTime": "20190817195700",
+        "jackpot": [
+            "$71,000,000"
+        ],
+        "numbers": "2,13,20,31,34|14",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$71,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 5,
+                        "prize": "$9,845"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 16,
+                        "prize": "$1,538"
+                    },
+                    {
+                        "name": "4",
+                        "count": 413,
+                        "prize": "$99"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 690,
+                        "prize": "$53"
+                    },
+                    {
+                        "name": "3",
+                        "count": 17161,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 8447,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 42589,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 66744,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3378",
+        "winnerCount": 136065
+    },
+    {
+        "drawTime": "20190814195700",
+        "jackpot": [
+            "$70,000,000"
+        ],
+        "numbers": "6,38,44,45,47|15",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$70,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 3,
+                        "prize": "$16,083"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 18,
+                        "prize": "$1,340"
+                    },
+                    {
+                        "name": "4",
+                        "count": 379,
+                        "prize": "$106"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 686,
+                        "prize": "$52"
+                    },
+                    {
+                        "name": "3",
+                        "count": 16279,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 8679,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 41468,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 64957,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3377",
+        "winnerCount": 132469
+    },
+    {
+        "drawTime": "20190810195700",
+        "jackpot": [
+            "$69,000,000"
+        ],
+        "numbers": "11,24,39,40,45|27",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$69,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$49,186"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 16,
+                        "prize": "$1,537"
+                    },
+                    {
+                        "name": "4",
+                        "count": 365,
+                        "prize": "$112"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 598,
+                        "prize": "$61"
+                    },
+                    {
+                        "name": "3",
+                        "count": 16118,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 8536,
+                        "prize": "$11"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 43688,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 66942,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3376",
+        "winnerCount": 136263
+    },
+    {
+        "drawTime": "20190807195700",
+        "jackpot": [
+            "$68,000,000"
+        ],
+        "numbers": "1,12,13,39,47|9",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$68,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 3,
+                        "prize": "$15,903"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 27,
+                        "prize": "$883"
+                    },
+                    {
+                        "name": "4",
+                        "count": 363,
+                        "prize": "$109"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 681,
+                        "prize": "$52"
+                    },
+                    {
+                        "name": "3",
+                        "count": 16806,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 9276,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 45917,
+                        "prize": "$1"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 69305,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3375",
+        "winnerCount": 142378
+    },
+    {
+        "drawTime": "20190803195700",
+        "jackpot": [
+            "$67,000,000"
+        ],
+        "numbers": "17,18,21,27,32|23",
+        "breakdown": [
+            {
+                "name": "main",
+                "detail": [
+                    {
+                        "name": "5 + Mega",
+                        "count": 0,
+                        "prize": "$67,000,000"
+                    },
+                    {
+                        "name": "5",
+                        "count": 0,
+                        "prize": "$49,147"
+                    },
+                    {
+                        "name": "4 + Mega",
+                        "count": 12,
+                        "prize": "$2,047"
+                    },
+                    {
+                        "name": "4",
+                        "count": 406,
+                        "prize": "$100"
+                    },
+                    {
+                        "name": "3 + Mega",
+                        "count": 695,
+                        "prize": "$53"
+                    },
+                    {
+                        "name": "3",
+                        "count": 17931,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "2 + Mega",
+                        "count": 9078,
+                        "prize": "$10"
+                    },
+                    {
+                        "name": "1 + Mega",
+                        "count": 44508,
+                        "prize": "$2"
+                    },
+                    {
+                        "name": "Mega",
+                        "count": 67207,
+                        "prize": "$1"
+                    }
+                ]
+            }
+        ],
+        "other": [],
+        "name": "Superlotto Plus",
+        "lotteryID": "us_ca-superlotto-plus",
+        "issue": "3374",
+        "winnerCount": 139837
+    }
+]

--- a/crawler/us/ca/latest/crawler.js
+++ b/crawler/us/ca/latest/crawler.js
@@ -4,19 +4,26 @@ const VError = require('verror')
 function createCrawler (config) {
   return {
     crawl: async () => {
-      let result = await API.getDrawGamePastDrawResults(config)
-      if (result.error) {
-        await API.wait(5000) // retry 1
-        result = await API.getDrawGamePastDrawResults(config)
-      }
-      if (result.error) {
-        await API.wait(5000) // retry 2
-        result = await API.getDrawGamePastDrawResults(config)
-      }
+      const result = await API.retry(async () => {
+        const crawlerResult = await API.getDrawGamePastDrawResults(config)
+        return crawlerResult
+      }, 3)
       if (result.error === null) {
         return result.data
       } else {
-        throw new VError(result.error, `${config.lotteryId} 获取最新结果出错`)
+        throw new VError(result.error, `${config.lotteryID} 获取最新结果出错`)
+      }
+    },
+
+    history: async () => {
+      const result = await API.retry(async () => {
+        const crawlerResult = await API.getDrawGameHistoryDrawResults(config)
+        return crawlerResult
+      }, 3)
+      if (result.error === null) {
+        return result.data
+      } else {
+        throw new VError(result.error, `${config.lotteryID} 获取历史结果出错`)
       }
     }
   }

--- a/crawler/us/ca/tests/test-crawler.js
+++ b/crawler/us/ca/tests/test-crawler.js
@@ -1,11 +1,11 @@
 const CrawlerMap = require('../index')
 /*
- * node .\crawler\us\ca\tests\test-crawler.js us-ca-daily-3
- * node .\crawler\us\ca\tests\test-crawler.js us-ca-daily-4
- * node .\crawler\us\ca\tests\test-crawler.js us-ca-fantasy-5
- * node .\crawler\us\ca\tests\test-crawler.js us-ca-mega-millions
- * node .\crawler\us\ca\tests\test-crawler.js us-ca-powerball
- * node .\crawler\us\ca\tests\test-crawler.js us-ca-superlotto-plus
+ * node .\crawler\us\ca\tests\test-crawler.js us_ca-daily-3
+ * node .\crawler\us\ca\tests\test-crawler.js us_ca-daily-4
+ * node .\crawler\us\ca\tests\test-crawler.js us_ca-fantasy-5
+ * node .\crawler\us\ca\tests\test-crawler.js us_ca-mega-millions
+ * node .\crawler\us\ca\tests\test-crawler.js us_ca-powerball
+ * node .\crawler\us\ca\tests\test-crawler.js us_ca-superlotto-plus
 */
 async function test () {
   const crawlerId = process.argv[2]

--- a/crawler/us/ca/tests/test-history.js
+++ b/crawler/us/ca/tests/test-history.js
@@ -1,0 +1,30 @@
+const CrawlerMap = require('../index')
+const fs = require('fs')
+const path = require('path')
+/*
+ * node .\crawler\us\ca\tests\test-history.js us_ca-daily-3
+ * node .\crawler\us\ca\tests\test-history.js us_ca-daily-4
+ * node .\crawler\us\ca\tests\test-history.js us_ca-fantasy-5
+ * node .\crawler\us\ca\tests\test-history.js us_ca-mega-millions
+ * node .\crawler\us\ca\tests\test-history.js us_ca-powerball
+ * node .\crawler\us\ca\tests\test-history.js us_ca-superlotto-plus
+*/
+async function test () {
+  const crawlerId = process.argv[2]
+  if (crawlerId) {
+    const crawler = CrawlerMap.get(crawlerId)
+    if (crawler) {
+      const result = await crawler[0].history()
+      fs.writeFileSync(path.join(__dirname, '../history/', `${crawlerId}.json`), JSON.stringify(result, null, 4))
+    } else {
+      console.log(`${crawlerId} is not exist`)
+    }
+  } else {
+    CrawlerMap.forEach(async function (crawler, key) {
+      const result = await crawler[0].history()
+      fs.writeFileSync(path.join(__dirname, '../history/', `${key}.json`), JSON.stringify(result, null, 4))
+    })
+  }
+}
+
+test()


### PR DESCRIPTION
当前抓取数据存放目录 crawler\us\ca\history
抓取脚本
 * node .\crawler\us\ca\tests\test-history.js us_ca-daily-3
 * node .\crawler\us\ca\tests\test-history.js us_ca-daily-4
 * node .\crawler\us\ca\tests\test-history.js us_ca-fantasy-5
 * node .\crawler\us\ca\tests\test-history.js us_ca-mega-millions
 * node .\crawler\us\ca\tests\test-history.js us_ca-powerball
 * node .\crawler\us\ca\tests\test-history.js us_ca-superlotto-plus