### PR TITLE
日本历史数据爬取

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,9 @@ data/
 
 # Playground
 /play.js
+
+# jp history file
+/crawler/jp/history/*
+!/crawler/jp/history/tmp
+/crawler/jp/history/tmp/*
+!/crawler/jp/history/tmp/.gitkeep

--- a/crawler/jp/README.md
+++ b/crawler/jp/README.md
@@ -1,0 +1,28 @@
+<!--
+ * @Author: maple
+ * @Date: 2020-08-07 20:00:33
+ * @LastEditors: maple
+ * @LastEditTime: 2020-08-07 21:58:38
+-->
+# 用法
+
+```
+node history
+```
+
+## 文件目录
+```
+├── history
+│   ├── tmp --------------------- 中间文件层，生成多个以 id 为名称的 json文件
+│   ├── jp-bingo5.JSON
+│   ├── jp-kisekaeqoochan.JSON
+│   ├── jp-loto6.JSON
+│   ├── jp-loto7.JSON
+│   ├── jp-miniloto.JSON
+│   ├── jp-numbers3.JSON
+│   └── jp-numbers4.JSON
+```
+
+## history/tmp 文件夹
+
+中间文件层，生成多个以 id 为名称的 json 文件。用于重复获取历史信息 & 重复爬取失败的文件。如果需要强制重新爬取，需要删除 tmp 文件夹

--- a/crawler/jp/crawlers/common/bingo.js
+++ b/crawler/jp/crawlers/common/bingo.js
@@ -4,7 +4,7 @@
  * @Author: maple
  * @Date: 2020-08-05 21:18:36
  * @LastEditors: maple
- * @LastEditTime: 2020-08-07 14:15:39
+ * @LastEditTime: 2020-08-07 19:14:19
  */
 const crawler = require('./crawler')
 const { moneyFormat } = require('../../../../util/format')
@@ -97,13 +97,13 @@ function format (text, config = {}) {
   return result
 }
 
-async function main (config = {}) {
+async function main (config = {}, id) {
   const {
-    mainName = 'loto',
-    name = 'loto7'
+    mainName = 'bingo',
+    name = 'bingo5'
   } = config
 
-  const text = await crawler(name, mainName)
+  const text = await crawler(name, mainName, id)
   const result = format(text, config)
 
   return result

--- a/crawler/jp/crawlers/common/crawler.js
+++ b/crawler/jp/crawlers/common/crawler.js
@@ -2,7 +2,7 @@
  * @Author: maple
  * @Date: 2020-08-05 21:19:37
  * @LastEditors: maple
- * @LastEditTime: 2020-08-06 03:31:17
+ * @LastEditTime: 2020-08-07 18:49:21
  */
 const VError = require('verror')
 
@@ -25,7 +25,7 @@ async function crawler (name, mainName) {
   if (mainName === 'bingo' || mainName === 'numbers' || mainName === 'qoochan') {
     const nameURL = urlsGet.getNameCSVURL(name, mainName)
 
-    log.info(`爬取 name csv url: ${nameURL}`)
+    log.debug(`爬取 name csv url: ${nameURL}`)
 
     const nameText = await fileGet(nameURL)
     const csvNames = csvNamesFormat(nameText)
@@ -52,7 +52,7 @@ async function crawler (name, mainName) {
   } else {
     const nameURL = urlsGet.getNameTXTURL(name)
 
-    log.info(`爬取 name url: ${nameURL}`)
+    log.debug(`爬取 name url: ${nameURL}`)
 
     const nameText = await fileGet(nameURL)
     const csvNames = txtNamesFormat(nameText)
@@ -66,7 +66,7 @@ async function crawler (name, mainName) {
   // 这里 Numbers3 和 Numbers4 其实是同个文件
   const csvURL = urlsGet.getCSVURL(name, lastCsvName, mainName)
 
-  log.info(`爬取 csv url: ${csvURL}`)
+  log.debug(`爬取 csv url: ${csvURL}`)
 
   // 真实文件数据
   const csvText = await fileGet(csvURL)

--- a/crawler/jp/crawlers/common/crawler.js
+++ b/crawler/jp/crawlers/common/crawler.js
@@ -2,7 +2,7 @@
  * @Author: maple
  * @Date: 2020-08-05 21:19:37
  * @LastEditors: maple
- * @LastEditTime: 2020-08-07 18:49:21
+ * @LastEditTime: 2020-08-07 19:35:48
  */
 const VError = require('verror')
 
@@ -12,6 +12,38 @@ const txtNamesFormat = require('./txt_names_format')
 const csvNamesFormat = require('./csv_names_format')
 const fileGet = require('./get_file_text')
 
+function getCSVNameById (name, id) {
+  let prefix
+  switch (name) {
+    case 'bingo5':
+      prefix = 'A104'
+      break
+    case 'numbers3':
+      prefix = 'A100'
+      break
+    case 'numbers4':
+      prefix = 'A100'
+      break
+    case 'kisekae-qoochan':
+      prefix = 'A105'
+      break
+    case 'loto6':
+      prefix = 'A102'
+      break
+    case 'loto7':
+      prefix = 'A103'
+      break
+    case 'miniloto':
+      prefix = 'A101'
+      break
+    default:
+      prefix = `unknown_name_${name}`
+      break
+  }
+
+  return `${prefix}${('0000' + id).slice(-4, 10)}.CSV`
+}
+
 /**
  * 爬取彩票实际数据的文本
  * 乐透三个彩票可以通过 name.txt 来获取真实 CSV 名称
@@ -19,40 +51,24 @@ const fileGet = require('./get_file_text')
  * @param {string} name 彩票名称
  * @param {string} mainName 彩票类别
  */
-async function crawler (name, mainName) {
+async function crawler (name, mainName, id) {
   // 获得 CSV 文件名
   let lastCsvName
-  if (mainName === 'bingo' || mainName === 'numbers' || mainName === 'qoochan') {
+  if (id !== undefined) {
+    lastCsvName = getCSVNameById(name, id)
+  } else if (mainName === 'bingo' || mainName === 'numbers' || mainName === 'qoochan') {
     const nameURL = urlsGet.getNameCSVURL(name, mainName)
 
-    log.debug(`爬取 name csv url: ${nameURL}`)
+    log.info(`爬取 name csv url: ${nameURL}`)
 
     const nameText = await fileGet(nameURL)
     const csvNames = csvNamesFormat(nameText)
 
-    let prefix
-    switch (name) {
-      case 'bingo5':
-        prefix = 'A104'
-        break
-      case 'numbers3':
-        prefix = 'A100'
-        break
-      case 'numbers4':
-        prefix = 'A100'
-        break
-      case 'kisekae-qoochan':
-        prefix = 'A105'
-        break
-      default:
-        break
-    }
-
-    lastCsvName = `${prefix}${('0000' + csvNames[0]).slice(-4, 10)}.CSV`
+    lastCsvName = getCSVNameById(name, csvNames[0])
   } else {
     const nameURL = urlsGet.getNameTXTURL(name)
 
-    log.debug(`爬取 name url: ${nameURL}`)
+    log.info(`爬取 name url: ${nameURL}`)
 
     const nameText = await fileGet(nameURL)
     const csvNames = txtNamesFormat(nameText)
@@ -66,7 +82,7 @@ async function crawler (name, mainName) {
   // 这里 Numbers3 和 Numbers4 其实是同个文件
   const csvURL = urlsGet.getCSVURL(name, lastCsvName, mainName)
 
-  log.debug(`爬取 csv url: ${csvURL}`)
+  log.info(`爬取 csv url: ${csvURL}`)
 
   // 真实文件数据
   const csvText = await fileGet(csvURL)

--- a/crawler/jp/crawlers/common/issue_and_draw_time.js
+++ b/crawler/jp/crawlers/common/issue_and_draw_time.js
@@ -2,7 +2,7 @@
  * @Author: maple
  * @Date: 2020-08-07 13:52:04
  * @LastEditors: maple
- * @LastEditTime: 2020-08-07 14:20:12
+ * @LastEditTime: 2020-08-07 21:52:09
  */
 const VError = require('verror')
 const moment = require('moment')
@@ -12,6 +12,7 @@ function deal (line) {
   const tmps = line.split(',')
 
   let ReiwaYear
+  let HeiseiYear
   let month
   let day
 
@@ -27,14 +28,25 @@ function deal (line) {
       ReiwaYear = parseInt(t.slice(2, yearAt))
       month = parseInt(t.slice(yearAt + 1, monthAt))
       day = parseInt(t.slice(monthAt + 1, dayAt))
+    } else if (t.indexOf('平成') === 0) {
+      const yearAt = t.indexOf('年')
+      const monthAt = t.indexOf('月')
+      const dayAt = t.indexOf('日')
+
+      if (!yearAt || !monthAt || !dayAt) {
+        continue
+      }
+      HeiseiYear = parseInt(t.slice(2, yearAt))
+      month = parseInt(t.slice(yearAt + 1, monthAt))
+      day = parseInt(t.slice(monthAt + 1, dayAt))
     }
   }
 
-  if (!ReiwaYear || !month || !day) {
+  if (!(ReiwaYear || HeiseiYear) || !month || !day) {
     throw new VError('爬取开奖时间错误')
   }
 
-  const year = ReiwaYear + 2018
+  const year = ReiwaYear ? HeiseiYear + 2018 : HeiseiYear + 1988
   const date = moment()
   date.set('years', year)
   date.set('months', month - 1)

--- a/crawler/jp/crawlers/common/loto.js
+++ b/crawler/jp/crawlers/common/loto.js
@@ -3,7 +3,7 @@
  * @Author: maple
  * @Date: 2020-08-05 21:18:36
  * @LastEditors: maple
- * @LastEditTime: 2020-08-07 14:17:28
+ * @LastEditTime: 2020-08-07 19:21:40
  */
 const crawler = require('./crawler')
 const dateDeal = require('./issue_and_draw_time')
@@ -98,13 +98,13 @@ function format (text, config = {}) {
   return result
 }
 
-async function main (config = {}) {
+async function main (config = {}, id) {
   const {
     mainName = 'loto',
     name = 'loto7'
   } = config
 
-  const text = await crawler(name, mainName)
+  const text = await crawler(name, mainName, id)
 
   const result = format(text, config)
 

--- a/crawler/jp/crawlers/common/numbers.js
+++ b/crawler/jp/crawlers/common/numbers.js
@@ -3,7 +3,7 @@
  * @Author: maple
  * @Date: 2020-08-05 21:18:36
  * @LastEditors: maple
- * @LastEditTime: 2020-08-07 14:18:13
+ * @LastEditTime: 2020-08-07 19:22:03
  */
 const crawler = require('./crawler')
 const dateDeal = require('./issue_and_draw_time')
@@ -102,13 +102,13 @@ function format (text, config = {}) {
   return result
 }
 
-async function main (config = {}) {
+async function main (config = {}, id) {
   const {
     mainName = 'numbers',
     name = 'numbers3'
   } = config
 
-  const text = await crawler(name, mainName)
+  const text = await crawler(name, mainName, id)
 
   const result = format(text, config)
 

--- a/crawler/jp/crawlers/common/qoochan.js
+++ b/crawler/jp/crawlers/common/qoochan.js
@@ -3,7 +3,7 @@
 * @Author: maple
 * @Date: 2020-08-05 21:18:36
  * @LastEditors: maple
- * @LastEditTime: 2020-08-07 14:18:51
+ * @LastEditTime: 2020-08-07 19:22:26
 */
 const crawler = require('./crawler')
 const dateDeal = require('./issue_and_draw_time')
@@ -95,13 +95,13 @@ function format (text, config = {}) {
   return result
 }
 
-async function main (config = {}) {
+async function main (config = {}, id) {
   const {
     mainName = 'loto',
     name = 'loto7'
   } = config
 
-  const text = await crawler(name, mainName)
+  const text = await crawler(name, mainName, id)
 
   const result = format(text, config)
 

--- a/crawler/jp/crawlers/jp-bingo5/index.js
+++ b/crawler/jp/crawlers/jp-bingo5/index.js
@@ -2,13 +2,13 @@
  * @Author: maple
  * @Date: 2020-08-05 21:18:22
  * @LastEditors: maple
- * @LastEditTime: 2020-08-06 02:19:11
+ * @LastEditTime: 2020-08-07 19:19:29
  */
 const VError = require('verror')
 
 const bingoCommon = require('../common/bingo')
 
-async function crawl () {
+async function crawl (id) {
   const config = {
     mainName: 'bingo',
     name: 'bingo5',
@@ -19,7 +19,7 @@ async function crawl () {
     specialNumber: 0
   }
   try {
-    const result = await bingoCommon(config)
+    const result = await bingoCommon(config, id)
     return result
   } catch (err) {
     throw new VError(`${config.lotteryID}没有抓到数据，可能数据源不可用或有更改，请检查调度策略。detail: ${err.name} - ${err.message}`)

--- a/crawler/jp/crawlers/jp-kisekaeqoochan/index.js
+++ b/crawler/jp/crawlers/jp-kisekaeqoochan/index.js
@@ -2,13 +2,13 @@
  * @Author: maple
  * @Date: 2020-08-05 21:18:26
  * @LastEditors: maple
- * @LastEditTime: 2020-08-06 02:20:50
+ * @LastEditTime: 2020-08-07 19:24:32
  */
 const VError = require('verror')
 
 const qoochanCommon = require('../common/qoochan')
 
-async function crawl () {
+async function crawl (id) {
   const config = {
     mainName: 'qoochan',
     name: 'kisekae-qoochan',
@@ -19,7 +19,7 @@ async function crawl () {
     specialNumber: 0
   }
   try {
-    const result = await qoochanCommon(config)
+    const result = await qoochanCommon(config, id)
     return result
   } catch (err) {
     throw new VError(`${config.lotteryID}没有抓到数据，可能数据源不可用或有更改，请检查调度策略。detail: ${err.name} - ${err.message}`)

--- a/crawler/jp/crawlers/jp-loto6/index.js
+++ b/crawler/jp/crawlers/jp-loto6/index.js
@@ -2,12 +2,12 @@
  * @Author: maple
  * @Date: 2020-08-05 21:18:29
  * @LastEditors: maple
- * @LastEditTime: 2020-08-06 02:21:38
+ * @LastEditTime: 2020-08-07 19:24:40
  */
 const VError = require('verror')
 const lotoCommon = require('../common/loto')
 
-async function crawl () {
+async function crawl (id) {
   const config = {
     mainName: 'loto',
     name: 'loto6',
@@ -18,7 +18,7 @@ async function crawl () {
     specialNumber: 1
   }
   try {
-    const result = await lotoCommon(config)
+    const result = await lotoCommon(config, id)
     return result
   } catch (err) {
     throw new VError(`${config.lotteryID}没有抓到数据，可能数据源不可用或有更改，请检查调度策略。detail: ${err.name} - ${err.message}`)

--- a/crawler/jp/crawlers/jp-loto7/index.js
+++ b/crawler/jp/crawlers/jp-loto7/index.js
@@ -2,12 +2,12 @@
  * @Author: maple
  * @Date: 2020-08-05 21:18:36
  * @LastEditors: maple
- * @LastEditTime: 2020-08-06 02:22:09
+ * @LastEditTime: 2020-08-07 19:24:49
  */
 const VError = require('verror')
 const lotoCommon = require('../common/loto')
 
-async function crawl () {
+async function crawl (id) {
   const config = {
     mainName: 'loto',
     name: 'loto7',
@@ -18,7 +18,7 @@ async function crawl () {
     specialNumber: 2
   }
   try {
-    const result = await lotoCommon(config)
+    const result = await lotoCommon(config, id)
     return result
   } catch (err) {
     throw new VError(`${config.lotteryID}没有抓到数据，可能数据源不可用或有更改，请检查调度策略。detail: ${err.name} - ${err.message}`)

--- a/crawler/jp/crawlers/jp-miniloto/index.js
+++ b/crawler/jp/crawlers/jp-miniloto/index.js
@@ -2,12 +2,12 @@
  * @Author: maple
  * @Date: 2020-08-05 21:18:36
  * @LastEditors: maple
- * @LastEditTime: 2020-08-06 02:22:49
+ * @LastEditTime: 2020-08-07 19:24:56
  */
 const VError = require('verror')
 const lotoCommon = require('../common/loto')
 
-async function crawl () {
+async function crawl (id) {
   const config = {
     mainName: 'loto',
     name: 'miniloto',
@@ -18,7 +18,7 @@ async function crawl () {
     specialNumber: 1
   }
   try {
-    const result = await lotoCommon(config)
+    const result = await lotoCommon(config, id)
     return result
   } catch (err) {
     throw new VError(`${config.lotteryID}没有抓到数据，可能数据源不可用或有更改，请检查调度策略。detail: ${err.name} - ${err.message}`)

--- a/crawler/jp/crawlers/jp-numbers3/index.js
+++ b/crawler/jp/crawlers/jp-numbers3/index.js
@@ -2,12 +2,12 @@
  * @Author: maple
  * @Date: 2020-08-05 21:18:39
  * @LastEditors: maple
- * @LastEditTime: 2020-08-06 02:23:31
+ * @LastEditTime: 2020-08-07 19:25:04
  */
 const VError = require('verror')
 const numbersCommon = require('../common/numbers')
 
-async function crawl () {
+async function crawl (id) {
   const config = {
     mainName: 'numbers',
     name: 'numbers3',
@@ -17,7 +17,7 @@ async function crawl () {
     specialNumber: 0
   }
   try {
-    const result = await numbersCommon(config)
+    const result = await numbersCommon(config, id)
     return result
   } catch (err) {
     throw new VError(`${config.lotteryID}没有抓到数据，可能数据源不可用或有更改，请检查调度策略。detail: ${err.name} - ${err.message}`)

--- a/crawler/jp/crawlers/jp-numbers4/index.js
+++ b/crawler/jp/crawlers/jp-numbers4/index.js
@@ -2,12 +2,12 @@
  * @Author: maple
  * @Date: 2020-08-05 21:18:49
  * @LastEditors: maple
- * @LastEditTime: 2020-08-06 02:23:57
+ * @LastEditTime: 2020-08-07 19:25:14
  */
 const VError = require('verror')
 const numbersCommon = require('../common/numbers')
 
-async function crawl () {
+async function crawl (id) {
   const config = {
     mainName: 'numbers',
     name: 'numbers4',
@@ -17,7 +17,7 @@ async function crawl () {
     specialNumber: 0
   }
   try {
-    const result = await numbersCommon(config)
+    const result = await numbersCommon(config, id)
     return result
   } catch (err) {
     throw new VError(`${config.lotteryID}没有抓到数据，可能数据源不可用或有更改，请检查调度策略。detail: ${err.name} - ${err.message}`)

--- a/crawler/jp/history.js
+++ b/crawler/jp/history.js
@@ -1,0 +1,151 @@
+/**
+ * @Author: maple
+ * @Date: 2020-08-07 17:40:43
+ * @LastEditors: maple
+ * @LastEditTime: 2020-08-07 19:01:27
+ */
+const fs = require('fs')
+const util = require('util')
+const path = require('path')
+
+const writeFile = util.promisify(fs.writeFile)
+const readFile = util.promisify(fs.readFile)
+const mkdir = util.promisify(fs.mkdir)
+
+const log = require('../../util/log')
+const crawlers = require('./index')
+
+const crawlerRanges = {
+  'jp-bingo5': [171, 'lasted'],
+  // 'jp-kisekaeqoochan': ['lasted100', 'lasted'],
+  // 'jp-loto6': ['lasted100', 'lasted'],
+  // 'jp-loto7': ['lasted100', 'lasted'],
+  // 'jp-numbers3': ['lasted100', 'lasted'],
+  // 'jp-numbers4': ['lasted100', 'lasted'],
+  // 'jp-miniloto': ['lasted100', 'lasted']
+}
+
+async function saveData (name, id, data) {
+  const filePath = path.join(__dirname, 'history/tmp', name, `${id}.JSON`)
+  await writeFile(filePath, JSON.stringify(data))
+}
+
+async function saveResultData (name, data) {
+  const filePath = path.join(__dirname, 'history', `${name}.JSON`)
+  await writeFile(filePath, JSON.stringify(data))
+}
+
+async function tryGetFile (name, id) {
+  const filePath = path.join(__dirname, 'history/tmp', name, `${id}.JSON`)
+  console.log(filePath)
+  try {
+    return await readFile(filePath, { encoding: 'utf8' })
+  } catch (err) {
+    return null
+  }
+}
+
+async function polymerizeData (name, startId, endId) {
+  const total = endId - startId + 1
+  let tmp = endId
+  let success = 0
+  let failure = 0
+
+  const datas = []
+
+  while (tmp >= startId) {
+    const data = await tryGetFile(name, tmp)
+    if (data) {
+      datas.push(data)
+      console.log(datas)
+      success++
+    } else {
+      failure++
+    }
+
+    tmp--
+  }
+
+  log.info(`jp 历史数据爬取 LotteryId: ${name} 要求总数: ${total} 成功: ${success} 失败: ${failure}`)
+
+  try {
+    await saveResultData(name, datas)
+    log.info(`jp 历史数据爬取 LotteryId: ${name} 保存文件成功`)
+  } catch (err) {
+    log.info(`jp 历史数据爬取 LotteryId: ${name} 保存文件失败`, err)
+  }
+}
+
+async function mkdirFloder (name) {
+  try {
+    await mkdir(path.join(__dirname, 'history/tmp', name))
+  } catch (err) {
+    // do nothing
+  }
+}
+
+async function done () {
+  for (const [name, datas] of crawlers) {
+    log.info(`jp 历史数据爬取 Lottery Start id: ${name}`)
+
+    const crawler = datas[0].crawl
+
+    // 0. 初始化文件
+    await mkdirFloder(name)
+
+    // 1. 检查爬取范围
+    const crawlerRange = crawlerRanges[name]
+    let crawlerStart = crawlerRange[0]
+    let crawkerEnd = crawlerRange[1]
+
+    if (crawkerEnd === 'lasted') {
+      const lastData = await crawler()
+      crawkerEnd = lastData.issue
+    }
+
+    if (crawlerStart === 'lasted100') {
+      crawlerStart = crawkerEnd - 99
+    }
+
+    if (crawlerStart < 1) {
+      crawlerStart = 1
+    }
+
+    if (crawlerStart > crawkerEnd) {
+      crawlerStart = crawkerEnd
+    }
+
+    log.info(`jp 历史数据爬取 Lottery id: ${name} 范围: ${crawlerStart} - ${crawkerEnd}`)
+
+    // 2. 开始爬取流程
+    for (let i = crawkerEnd; i >= crawlerStart; i--) {
+      // 2.1 检查单个信息文件是否已存在
+      let data = await tryGetFile(name, i)
+
+      // 文件存在结束本次爬取
+      if (data) {
+        log.debug(`jp 历史数据爬取 LotteryId: ${name} id: ${i} 已存在数据，跳过`)
+        // 数据已存在 json 文件中
+        continue
+      }
+
+      // 2.2 爬取信息
+      try {
+        data = await crawler(i)
+      } catch (err) {
+        log.error(`jp 历史数据爬取 LotteryId: ${name} id: ${i} 错误`, err)
+      }
+
+      // 2.3 写入到文件
+      await saveData(name, i, data)
+    }
+    log.info(`jp 历史数据爬取 LotteryId: ${name} 聚合数据 Start`)
+    // 3. 聚合文件到一个总 JSON
+    await polymerizeData(name, crawlerStart, crawkerEnd)
+
+    // test
+    break
+  }
+}
+
+done()

--- a/crawler/jp/index.js
+++ b/crawler/jp/index.js
@@ -2,7 +2,7 @@
  * @Author: maple
  * @Date: 2020-08-05 20:58:46
  * @LastEditors: maple
- * @LastEditTime: 2020-08-07 13:32:24
+ * @LastEditTime: 2020-08-07 19:35:56
  */
 
 const Bingo5 = require('./crawlers/jp-bingo5')


### PR DESCRIPTION
<!--
 * @Author: maple
 * @Date: 2020-08-07 20:00:33
 * @LastEditors: maple
 * @LastEditTime: 2020-08-07 21:58:38
-->
# 用法

```
node history
```

## 文件目录
```
├── history
│   ├── tmp --------------------- 中间文件层，生成多个以 id 为名称的 json文件
│   ├── jp-bingo5.JSON
│   ├── jp-kisekaeqoochan.JSON
│   ├── jp-loto6.JSON
│   ├── jp-loto7.JSON
│   ├── jp-miniloto.JSON
│   ├── jp-numbers3.JSON
│   └── jp-numbers4.JSON
```

## history/tmp 文件夹

中间文件层，生成多个以 id 为名称的 json 文件。用于重复获取历史信息 & 重复爬取失败的文件。如果需要强制重新爬取，需要删除 tmp 文件夹