### PR TITLE
增加瑞士彩票的抓取

### DIFF
--- a/crawler/ch/api.js
+++ b/crawler/ch/api.js
@@ -96,6 +96,10 @@ function parseBreakdown ($, $elements) {
   $elements.each((index, element) => {
     const breakdownItem = {}
     breakdownItem.name = $(element).find('td:nth-child(1)').text().trim()
+    const stars = $(element).find('.euromillions-quotes__game-table___superstar')
+    if (stars.length > 0) {
+      breakdownItem.name = `${breakdownItem.name} ${stars.length}`
+    }
     breakdownItem.count = parseNumber($(element).find('td:nth-child(2)').text().trim())
     breakdownItem.prize = `CHF ${$(element).find('td:nth-child(3)').text().trim()}`
     breakdowns.push(breakdownItem)

--- a/crawler/ch/api.js
+++ b/crawler/ch/api.js
@@ -1,0 +1,417 @@
+
+const axios = require('axios').default
+const moment = require('moment')
+const log = require('../../util/log')
+const time = require('../../util/time')
+const cheerio = require('cheerio')
+const LORO_BASE = 'https://jeux.loro.ch/games'
+const SWISSLOS_BASE = 'https://www.swisslos.ch/de'
+const NAME_DE_MAP = {
+  'Ordre exact': 'Genaue Reihenfolge',
+  'Tous les ordres': 'Alle Reihenfolgen',
+  Milieu: 'Mitte',
+  '1er Chiffre': '1. Ziffer'
+}
+
+function parseDrawDataMargic (config, response) {
+  const $ = cheerio.load(response.data)
+  const drawResults = $('.ltr-draw-result')
+  const datas = []
+  drawResults.each((index, drawResultElement) => {
+    const drawData = {
+      drawTime: null,
+      numbers: null,
+      jackpot: [],
+      breakdown: [{
+        name: config.name,
+        detail: []
+      }],
+      other: [],
+      name: config.name,
+      lotteryID: config.lotteryID,
+      issue: ''
+    }
+    const $drawResultElement = $(drawResultElement)
+    const breakdownNodes = $drawResultElement.find('.ltr-prize-breakdown-table tbody tr')
+    const drawTimeNode = $drawResultElement.find('#result-date')
+    const drawTime = moment(drawTimeNode.text(), 'dddd D MMMM YYYY', 'fr')
+    if (drawTime.isValid()) {
+      drawData.drawTime = drawTime.format('YYYYMMDD000000')
+    }
+    const drawNumberNodes = $drawResultElement.find('.ltr-winning-numbers li')
+    const numbers = []
+    drawNumberNodes.each((index, drawNumberElement) => {
+      numbers.push($(drawNumberElement).text().trim())
+    })
+    drawData.numbers = numbers.join('|')
+    breakdownNodes.each((index, breakdownElement) => {
+      const breadownItem = {
+        name: $(breakdownElement).find('td:nth-child(1)').text(),
+        prize: $(breakdownElement).find('td:nth-child(2)').text()
+      }
+      if (NAME_DE_MAP[breadownItem.name]) {
+        breadownItem.nameDe = NAME_DE_MAP[breadownItem.name]
+      }
+      drawData.breakdown[0].detail.push(breadownItem)
+    })
+    datas.push(drawData)
+  })
+  return datas
+}
+
+function parseDrawDataBanco (config, response) {
+  const $ = cheerio.load(response.data)
+  const drawResults = $('.ltr-draw-result')
+  const datas = []
+  drawResults.each((index, drawResultElement) => {
+    const drawData = {
+      drawTime: null,
+      numbers: null,
+      jackpot: [],
+      breakdown: [],
+      other: [],
+      name: config.name,
+      lotteryID: config.lotteryID,
+      issue: ''
+    }
+    const $drawResultElement = $(drawResultElement)
+    const drawTimeNode = $drawResultElement.find('.ltr-draw-result-main-game p strong')
+    const drawTime = moment(drawTimeNode.text(), 'dddd D MMMM YYYY', 'fr')
+    if (drawTime.isValid()) {
+      drawData.drawTime = drawTime.format('YYYYMMDD063000')
+    }
+    const drawNumberNodes = $drawResultElement.find('.ltr-winning-numbers li')
+    const numbers = []
+    drawNumberNodes.each((index, drawNumberElement) => {
+      numbers.push($(drawNumberElement).text().trim())
+    })
+    drawData.numbers = numbers.join(',')
+    datas.push(drawData)
+  })
+  return datas
+}
+
+function parseBreakdown ($, $elements) {
+  const breakdowns = []
+  $elements.each((index, element) => {
+    const breakdownItem = {}
+    breakdownItem.name = $(element).find('td:nth-child(1)').text().trim()
+    breakdownItem.count = parseNumber($(element).find('td:nth-child(2)').text().trim())
+    breakdownItem.prize = `CHF ${$(element).find('td:nth-child(3)').text().trim()}`
+    breakdowns.push(breakdownItem)
+  })
+  return breakdowns
+}
+
+function parseTextArray ($, $elements) {
+  return $elements.map((index, element) => {
+    return $(element).text().trim()
+  }).get()
+}
+
+function parseDrawDataLotto (config, response) {
+  const $ = cheerio.load(response.data)
+  const $lotto = $('.game-instructions .quotes__game')
+  const $joker = $('.game-instructions .quotes__extra-game')
+  const drawData = {
+    drawTime: null,
+    numbers: null,
+    jackpot: [],
+    nextDrawTime: null,
+    nextJackpot: [],
+    breakdown: [
+      {
+        name: 'lotto',
+        detail: []
+      },
+      {
+        name: 'joker',
+        detail: []
+      }
+    ],
+    other: [],
+    name: config.name,
+    lotteryID: config.lotteryID,
+    issue: ''
+  }
+  const currentDate = moment($('.js-datepicker-input').val(), 'DD.MM.YYYY')
+  const nextDrawDate = getNextDrawDate(currentDate, [3, 6])
+  drawData.drawTime = currentDate.format('YYYYMMDD190000')
+  drawData.nextDrawTime = nextDrawDate.format('YYYYMMDD190000')
+  drawData.nextJackpot = parseTextArray($, $('.quotes__game-jackpot-value'))
+  const numbers = parseTextArray($, $lotto.find('.actual-numbers__number___normal'))
+  const specNumbers = []
+  specNumbers.push($lotto.find('.actual-numbers__number___lucky').text().trim())
+  specNumbers.push($lotto.find('.actual-numbers__number___replay').text().trim())
+  const jokerNumbers = $joker.find('.actual-numbers__extra-game___number').text().trim()
+  drawData.numbers = `${numbers.join(',')}|${specNumbers.join('|')}|${jokerNumbers}`
+  drawData.breakdown[0].detail = parseBreakdown($, $('.game-instructions .quotes__game-table tbody tr'))
+  drawData.breakdown[1].detail = parseBreakdown($, $('.game-instructions .quotes__extra-game-table tbody tr'))
+  return [drawData]
+}
+
+function parseDrawDataEuromillions (config, response) {
+  const $ = cheerio.load(response.data)
+  const $euroMillions = $('.game-instructions .quotes__game').eq(0)
+  const $chance2 = $('.game-instructions .quotes__game').eq(1)
+  const $superStar = $('.game-instructions .quotes__extra-game')
+  const drawData = {
+    drawTime: null,
+    numbers: null,
+    jackpot: [],
+    nextJackpot: [],
+    breakdown: [
+      {
+        name: 'EuroMillions',
+        detail: []
+      }, {
+        name: '2 Chance',
+        detail: []
+      }, {
+        name: 'Super-Star',
+        detail: []
+      }
+    ],
+    other: [],
+    name: 'EuroMillions',
+    lotteryID: 'ch-euromillions',
+    issue: ''
+  }
+  const currentDate = moment($('.js-datepicker-input').val(), 'DD.MM.YYYY')
+  const nextDrawDate = getNextDrawDate(currentDate, [2, 5])
+  drawData.drawTime = currentDate.format('YYYYMMDD193000')
+  drawData.nextDrawTime = nextDrawDate.format('YYYYMMDD193000')
+  drawData.nextJackpot = parseTextArray($, $('.quotes__game-jackpot-value'))
+  const numbers = parseTextArray($, $euroMillions.find('.actual-numbers__number___normal'))
+  const specNumbers = parseTextArray($, $euroMillions.find('.actual-numbers__number___superstar'))
+  const chance2Numbers = parseTextArray($, $chance2.find('.actual-numbers__number___normal'))
+  const superStarNumbers = parseTextArray($, $superStar.find('.actual-numbers__number___superstar'))
+  drawData.numbers = `${numbers.join(',')}|${specNumbers.join(',')}|${chance2Numbers.join(',')}|${superStarNumbers.join('')}`
+  drawData.breakdown[0].detail = parseBreakdown($, $('.game-instructions .quotes__game-table tbody tr'))
+  drawData.breakdown[1].detail = parseBreakdown($, $('.game-instructions .quotes__extra-game-table').eq(0).find('tbody tr'))
+  drawData.breakdown[2].detail = parseBreakdown($, $('.game-instructions .quotes__extra-game-table').eq(1).find('tbody tr'))
+  return [drawData]
+}
+
+async function queryLoroDrawResult (config, pageNo) {
+  const url = `${LORO_BASE}/${config.gameId}/results?pageState=${pageNo}&toDraw=${config.templateId}`
+  const response = await axios.get(url)
+  let datas = null
+  if (response.status === 200) {
+    switch (config.gameId) {
+      case 'magic3':
+      case 'magic4': {
+        datas = parseDrawDataMargic(config, response)
+        break
+      }
+      case 'banco': {
+        datas = parseDrawDataBanco(config, response)
+        break
+      }
+    }
+  }
+  return {
+    response,
+    datas
+  }
+}
+
+async function querySwisslosDrawResult (config, currentDate) {
+  const url = `${SWISSLOS_BASE}/${config.gameId}/information/gewinnzahlen/gewinnzahlen-quoten.html`
+  let response = null
+  if (currentDate) {
+    const formData = [
+      `filterDate=${currentDate.format('DD.MM.YYYY')}`,
+      `formattedFilterDate=${currentDate.locale('de').format('dd, DD.MM.YYYY')}`,
+      `currentDate=${currentDate.format('DD.MM.YYYY')}`
+    ]
+    response = await axios.post(url, formData.join('&'))
+  } else {
+    response = await axios.get(url)
+  }
+
+  let datas = null
+  if (response.status === 200) {
+    switch (config.gameId) {
+      case 'swisslotto': {
+        datas = parseDrawDataLotto(config, response)
+        break
+      }
+      case 'euromillions': {
+        datas = parseDrawDataEuromillions(config, response)
+        break
+      }
+    }
+  }
+  return {
+    response,
+    datas
+  }
+}
+
+function getLastDrawDate (currentDate, weeks) {
+  const now = moment(currentDate)
+  now.subtract(1, 'days')
+  while (true) {
+    if (weeks.includes(now.isoWeekday())) {
+      break
+    } else {
+      now.subtract(1, 'days')
+    }
+  }
+  return now
+}
+
+function getNextDrawDate (currentDate, weeks) {
+  const now = moment(currentDate)
+  now.add(1, 'days')
+  while (true) {
+    if (weeks.includes(now.isoWeekday())) {
+      break
+    } else {
+      now.add(1, 'days')
+    }
+  }
+  return now
+}
+
+function parseNumber (text) {
+  return parseInt(text.replace(/[^0-9]/ig, ''))
+}
+
+async function getDrawGamePastDrawResults (config) {
+  try {
+    let crawlerResult = null
+    switch (config.gameId) {
+      case 'banco':
+      case 'magic3':
+      case 'magic4': {
+        const pageNo = 1
+        crawlerResult = await queryLoroDrawResult(config, pageNo)
+        break
+      }
+      case 'swisslotto':
+      case 'euromillions': {
+        crawlerResult = await querySwisslosDrawResult(config, null)
+        break
+      }
+    }
+    if (crawlerResult.response.status === 200) {
+      return {
+        error: null,
+        data: crawlerResult.datas[0]
+      }
+    } else {
+      return {
+        error: `response.status ${crawlerResult.response.status}`,
+        data: null
+      }
+    }
+  } catch (error) {
+    return {
+      error: `${error}`,
+      data: null
+    }
+  }
+}
+async function getLoroHistoryDrawResults (config) {
+  let result = []
+  try {
+    let pageNo = 1
+    while (true) {
+      const { response, datas } = await queryLoroDrawResult(config, pageNo)
+      if (response.status === 200) {
+        result = result.concat(datas)
+        log.info(`${config.lotteryID}|${pageNo}|${result.length}|success`)
+      }
+      if (result.length >= 100) {
+        return {
+          error: null,
+          data: result
+        }
+      }
+      await time.wait(5000)
+      pageNo++
+    }
+  } catch (error) {
+    return {
+      error: `${error}`,
+      data: []
+    }
+  }
+}
+async function getDrawGameHistoryDrawResults (config) {
+  switch (config.gameId) {
+    case 'banco':
+    case 'magic3':
+    case 'magic4': {
+      const result = await getLoroHistoryDrawResults(config)
+      return result
+    }
+    case 'swisslotto':
+    case 'euromillions': {
+      const result = await getEuroMillionsHistoryDrawResults(config)
+      return result
+    }
+  }
+}
+
+async function getEuroMillionsHistoryDrawResults (config) {
+  let result = []
+  try {
+    let currentDate = null
+    while (true) {
+      const { response, datas } = await querySwisslosDrawResult(config, currentDate)
+      if (response.status === 200) {
+        if (currentDate === null && datas[0]) {
+          currentDate = moment(datas[0].drawTime, 'YYYYMMDDHHmmss')
+        }
+        result = result.concat(datas)
+        log.info(`${config.lotteryID}|${currentDate.format('YYYY-MM-DD')}|${result.length}|success`)
+        switch (config.gameId) {
+          case 'swisslotto' : {
+            currentDate = getLastDrawDate(currentDate, [3, 6])
+            break
+          }
+          case 'euromillions' : {
+            currentDate = getLastDrawDate(currentDate, [2, 5])
+            break
+          }
+        }
+      }
+      if (result.length >= 100) {
+        return {
+          error: null,
+          data: result
+        }
+      }
+      await time.wait(5000)
+    }
+  } catch (error) {
+    return {
+      error: `${error}`,
+      data: []
+    }
+  }
+}
+
+async function retry (func, retryCount) {
+  let count = 0
+  while (true) {
+    const result = await func()
+    if (result.error) {
+      await time.wait(5000)
+    } else {
+      return result
+    }
+    count++
+    if (count >= retryCount) {
+      return result
+    }
+  }
+}
+module.exports = {
+  getDrawGamePastDrawResults,
+  getDrawGameHistoryDrawResults,
+  retry
+}

--- a/crawler/ch/index.js
+++ b/crawler/ch/index.js
@@ -1,0 +1,43 @@
+
+const Crawler = require('./latest/crawler')
+const crawlers = new Map()
+const CRAWLER_CONFIGS = [
+  {
+    gameId: 'magic3',
+    templateId: '2610',
+    name: 'Magic 3',
+    lotteryID: 'ch-magic-3'
+  },
+  {
+    gameId: 'magic4',
+    templateId: '1675',
+    name: 'Magic 4',
+    lotteryID: 'ch-magic-4'
+  },
+  {
+    gameId: 'banco',
+    templateId: '5455',
+    name: 'Banco',
+    lotteryID: 'ch-banco'
+  },
+  {
+    gameId: 'swisslotto',
+    templateId: '',
+    name: 'Lotto',
+    lotteryID: 'ch-lotto'
+  },
+  {
+    gameId: 'euromillions',
+    templateId: '',
+    name: 'EuroMillions',
+    lotteryID: 'ch-euromillions'
+  }
+]
+
+for (const config of CRAWLER_CONFIGS) {
+  crawlers.set(config.lotteryID,
+    [Crawler.createCrawler(config)]
+  )
+}
+
+module.exports = crawlers

--- a/crawler/ch/latest/crawler.js
+++ b/crawler/ch/latest/crawler.js
@@ -1,0 +1,57 @@
+
+const API = require('../api')
+const VError = require('verror')
+function createCrawler (config) {
+  return {
+    crawl: async (stepId) => {
+      const result = await API.retry(async () => {
+        const crawlerResult = await API.getDrawGamePastDrawResults(config)
+        return crawlerResult
+      }, 3)
+      if (result.error === null) {
+        const stepData = result.data
+        if (stepId) {
+          switch (stepId) {
+            case 'result': {
+              delete stepData.breakdown
+              delete stepData.other
+              return stepData
+            }
+            case 'breakdown': {
+              return {
+                drawTime: stepData.drawTime,
+                breakdown: stepData.breakdown
+              }
+            }
+            case 'other': {
+              return {
+                drawTime: stepData.drawTime,
+                other: stepData.other
+              }
+            }
+          }
+        } else {
+          return stepData
+        }
+      } else {
+        throw new VError(result.error, `${config.lotteryID} 获取最新结果出错`)
+      }
+    },
+
+    history: async () => {
+      const result = await API.retry(async () => {
+        const crawlerResult = await API.getDrawGameHistoryDrawResults(config)
+        return crawlerResult
+      }, 3)
+      if (result.error === null) {
+        return result.data
+      } else {
+        throw new VError(result.error, `${config.lotteryID} 获取历史结果出错`)
+      }
+    }
+  }
+}
+
+module.exports = {
+  createCrawler
+}

--- a/crawler/ch/tests/test-crawler.js
+++ b/crawler/ch/tests/test-crawler.js
@@ -1,0 +1,37 @@
+const CrawlerMap = require('../index')
+const log = require('../../../util/log')
+/*
+ * node ./crawler/ch/tests/test-crawler.js
+ * node ./crawler/ch/tests/test-crawler.js ch-magic-3
+ * node ./crawler/ch/tests/test-crawler.js ch-magic-4
+ * node ./crawler/ch/tests/test-crawler.js ch-banco
+ * node ./crawler/ch/tests/test-crawler.js ch-lotto
+ * node ./crawler/ch/tests/test-crawler.js ch-euromillions
+*/
+async function test () {
+  const crawlerId = process.argv[2]
+  if (crawlerId) {
+    const crawler = CrawlerMap.get(crawlerId)
+    if (crawler) {
+      const stepId = process.argv[3]
+      const result = await crawler[0].crawl(stepId)
+      log.info({
+        crawlerId,
+        response: result
+      })
+    } else {
+      log.info(`${crawlerId} is not exist`)
+    }
+  } else {
+    CrawlerMap.forEach(async function (crawler, key) {
+      const result = await crawler[0].crawl()
+      log.info(
+        {
+          crawlerId: key,
+          response: result
+        })
+    })
+  }
+}
+
+test()

--- a/crawler/ch/tests/test-history.js
+++ b/crawler/ch/tests/test-history.js
@@ -1,0 +1,31 @@
+const CrawlerMap = require('../index')
+const fs = require('fs')
+const path = require('path')
+const log = require('../../../util/log')
+/*
+ * node ./crawler/ch/tests/test-history.js
+ * node ./crawler/ch/tests/test-history.js ch-magic-3
+ * node ./crawler/ch/tests/test-history.js ch-magic-4
+ * node ./crawler/ch/tests/test-history.js ch-banco
+ * node ./crawler/ch/tests/test-history.js ch-lotto
+ * node ./crawler/ch/tests/test-history.js ch-euromillions
+*/
+async function test () {
+  const crawlerId = process.argv[2]
+  if (crawlerId) {
+    const crawler = CrawlerMap.get(crawlerId)
+    if (crawler) {
+      const result = await crawler[0].history()
+      fs.writeFileSync(path.join(__dirname, '../history/', `${crawlerId}.json`), JSON.stringify(result, null, 4))
+    } else {
+      log.info(`${crawlerId} is not exist`)
+    }
+  } else {
+    CrawlerMap.forEach(async function (crawler, key) {
+      const result = await crawler[0].history()
+      fs.writeFileSync(path.join(__dirname, '../history/', `${key}.json`), JSON.stringify(result, null, 4))
+    })
+  }
+}
+
+test()

--- a/package-lock.json
+++ b/package-lock.json
@@ -264,6 +264,11 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npm.taobao.org/boolbase/download/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -352,6 +357,19 @@
         }
       }
     },
+    "cheerio": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npm.taobao.org/cheerio/download/cheerio-1.0.0-rc.3.tgz",
+      "integrity": "sha1-CUY21CWy6cD065GkbAVjDJoai/Y=",
+      "requires": {
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.1",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
+      }
+    },
     "chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npm.taobao.org/chownr/download/chownr-1.1.4.tgz",
@@ -406,6 +424,22 @@
         "which": "^2.0.1"
       }
     },
+    "css-select": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npm.taobao.org/css-select/download/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "requires": {
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
+        "domutils": "1.5.1",
+        "nth-check": "~1.0.1"
+      }
+    },
+    "css-what": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npm.taobao.org/css-what/download/css-what-2.1.3.tgz",
+      "integrity": "sha1-ptdgRXM2X+dGhsPzEcVlE9iChfI="
+    },
     "dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npm.taobao.org/dateformat/download/dateformat-3.0.3.tgz",
@@ -447,6 +481,37 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npm.taobao.org/dom-serializer/download/dom-serializer-0.1.1.tgz",
+      "integrity": "sha1-HsQFnihLq+027sKUHUqXChic58A=",
+      "requires": {
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npm.taobao.org/domelementtype/download/domelementtype-1.3.1.tgz",
+      "integrity": "sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8="
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npm.taobao.org/domhandler/download/domhandler-2.4.2.tgz",
+      "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npm.taobao.org/domutils/download/domutils-1.5.1.tgz?cache=0&sync_timestamp=1597680539726&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdomutils%2Fdownload%2Fdomutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
     "dotenv": {
       "version": "8.2.0",
       "resolved": "https://registry.npm.taobao.org/dotenv/download/dotenv-8.2.0.tgz",
@@ -480,6 +545,11 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npm.taobao.org/entities/download/entities-1.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fentities%2Fdownload%2Fentities-1.1.2.tgz",
+      "integrity": "sha1-vfpzUplmTfr9NFKe1PhSKidf6lY="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -1025,6 +1095,19 @@
       "integrity": "sha1-dTm9S8Hg4KiVgVouAmJCCxKFhIg=",
       "dev": true
     },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npm.taobao.org/htmlparser2/download/htmlparser2-3.10.1.tgz?cache=0&sync_timestamp=1582421370976&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhtmlparser2%2Fdownload%2Fhtmlparser2-3.10.1.tgz",
+      "integrity": "sha1-vWedw/WYl7ajS7EHSchVu1OpOS8=",
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      }
+    },
     "https-proxy-agent": {
       "version": "4.0.0",
       "resolved": "https://registry.npm.taobao.org/https-proxy-agent/download/https-proxy-agent-4.0.0.tgz?cache=0&sync_timestamp=1581106853117&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttps-proxy-agent%2Fdownload%2Fhttps-proxy-agent-4.0.0.tgz",
@@ -1260,8 +1343,7 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "mime": {
       "version": "2.4.6",
@@ -1348,6 +1430,14 @@
           "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true
         }
+      }
+    },
+    "nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npm.taobao.org/nth-check/download/nth-check-1.0.2.tgz",
+      "integrity": "sha1-sr0pXDfj3VijvwcAN2Zjuk2c8Fw=",
+      "requires": {
+        "boolbase": "~1.0.0"
       }
     },
     "object-inspect": {
@@ -1447,6 +1537,14 @@
       "dev": true,
       "requires": {
         "error-ex": "^1.2.0"
+      }
+    },
+    "parse5": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npm.taobao.org/parse5/download/parse5-3.0.3.tgz",
+      "integrity": "sha1-BC95L/3TaFFVHPTp4Gazh0q0W1w=",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "path-exists": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "async-mutex": "^0.2.4",
     "axios": "^0.19.2",
     "bufferutil": "^4.0.1",
+    "cheerio": "^1.0.0-rc.3",
     "cron-parser": "^2.16.3",
     "encoding-japanese": "^1.0.30",
     "moment": "^2.27.0",

--- a/util/time.js
+++ b/util/time.js
@@ -42,8 +42,18 @@ function isExtraReady (drawTime, delay, tz) {
   return parseDrawTime(drawTime, tz).add(delay, 's').isBefore(moment().tz(tz))
 }
 
+function wait (second) {
+  const promise = new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve()
+    }, second)
+  })
+  return promise
+}
+
 module.exports = {
   sleep,
   hasNewDraw,
-  isExtraReady
+  isExtraReady,
+  wait
 }


### PR DESCRIPTION
验证脚本
 * node ./crawler/ch/tests/test-crawler.js ch-magic-3
 * node ./crawler/ch/tests/test-crawler.js ch-magic-4
 * node ./crawler/ch/tests/test-crawler.js ch-banco
 * node ./crawler/ch/tests/test-crawler.js ch-lotto
 * node ./crawler/ch/tests/test-crawler.js ch-euromillions
网站比较慢，翻墙会快一些
瑞士的彩票是2个网站
https://jeux.loro.ch 这个有API，API返回的是html片段，这个使用cheerio解析html
https://www.swisslos.ch 这个没有API，但是彩票的结果是直接html返回的，所以也使用cheerio解析html的方式